### PR TITLE
Require paths for truncate/fstat workarounds

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3996,6 +3996,14 @@ int main(int argc, char *argv[])
 	    parse_workarounds() == -1)
 		exit(1);
 
+#if FUSE_VERSION >= 29
+	// These workarounds require the "path" argument.
+	if (sshfs.truncate_workaround || sshfs.fstat_workaround) {
+		sshfs_oper.oper.flag_nullpath_ok = 0;
+		sshfs_oper.oper.flag_nopath = 0;
+	}
+#endif
+
 	if (sshfs.idmap == IDMAP_USER)
 		sshfs.detect_uid = 1;
 	else if (sshfs.idmap == IDMAP_FILE) {


### PR DESCRIPTION
Commit 74bfa3850a2568f96dd1d090a9386534c9bb4629 allowed sshfs to run
without requiring a non-NULL path argument for certain
operations. This was erroneous in the case of using certain
workarounds.