### PR TITLE
Port SSHFS to Cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,6 @@ have_fuse_opt_parse=no
 oldlibs="$LIBS"
 LIBS="$LIBS $SSHFS_LIBS"
 AC_CHECK_FUNC([fuse_opt_parse], [have_fuse_opt_parse=yes])
-AC_CHECK_FUNC([fsp_fuse_opt_parse], [have_fuse_opt_parse=yes])
 LIBS="$oldlibs"
 if test "$have_fuse_opt_parse" = no -o "$osname" = darwin; then
 	CFLAGS="$CFLAGS -I${srcdir}/compat"

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,7 @@ have_fuse_opt_parse=no
 oldlibs="$LIBS"
 LIBS="$LIBS $SSHFS_LIBS"
 AC_CHECK_FUNC([fuse_opt_parse], [have_fuse_opt_parse=yes])
+AC_CHECK_FUNC([fsp_fuse_opt_parse], [have_fuse_opt_parse=yes])
 LIBS="$oldlibs"
 if test "$have_fuse_opt_parse" = no -o "$osname" = darwin; then
 	CFLAGS="$CFLAGS -I${srcdir}/compat"

--- a/sshfs.c
+++ b/sshfs.c
@@ -11,7 +11,9 @@
 
 #include <fuse.h>
 #include <fuse_opt.h>
+#if !defined(__CYGWIN__)
 #include <fuse_lowlevel.h>
+#endif
 #ifdef __APPLE__
 #  include <fuse_darwin.h>
 #endif
@@ -4108,7 +4110,9 @@ int main(int argc, char *argv[])
 		char *mountpoint;
 		int multithreaded;
 		int foreground;
+#if !defined(__CYGWIN__)
 		struct stat st;
+#endif
 
 		res = fuse_parse_cmdline(&args, &mountpoint, &multithreaded,
 					 &foreground);
@@ -4120,20 +4124,26 @@ int main(int argc, char *argv[])
 			foreground = 1;
 		}
 
+#if !defined(__CYGWIN__)
 		res = stat(mountpoint, &st);
 		if (res == -1) {
 			perror(mountpoint);
 			exit(1);
 		}
 		sshfs.mnt_mode = st.st_mode;
+#elif defined(__CYGWIN__)
+		sshfs.mnt_mode = S_IFDIR | 0755;
+#endif
 
 		ch = fuse_mount(mountpoint, &args);
 		if (!ch)
 			exit(1);
 
+#if !defined(__CYGWIN__)
 		res = fcntl(fuse_chan_fd(ch), F_SETFD, FD_CLOEXEC);
 		if (res == -1)
 			perror("WARNING: failed to set FD_CLOEXEC on fuse device");
+#endif
 
 		sshfs.op = cache_init(&sshfs_oper);
 		fuse = fuse_new(ch, &args, sshfs.op,


### PR DESCRIPTION
The minimal commit in this PR allows SSHFS to be compiled and run on Cygwin.

This requires installation of "WinFsp", which is an open source project available here: http://www.secfs.net/winfsp/. WinFsp exposes FUSE-like file system functionality on Windows. It has its own native API, but also provides a FUSE 2.8 API.

At the time of this writing most core file system operations work correctly over SSHFS. The exceptions: are:
- Symlinks which are not yet supported on WinFsp. Support for symlinks (reparse points on Windows) should be coming soon.
- Hard links which will not be supported on WinFsp in the near future.
- Extended attributes which will not be supported on WinFsp in the near future.
