### PR TITLE
Remove call to g_slice_set_config()

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3949,9 +3949,6 @@ int main(int argc, char *argv[])
 	if (!realpath(*exec_path, sshfs_program_path)) {
 		memset(sshfs_program_path, 0, PATH_MAX);
 	}
-
-	/* Until this gets fixed somewhere else. */
-	g_slice_set_config(G_SLICE_CONFIG_ALWAYS_MALLOC, TRUE);
 #endif /* __APPLE__ */
 	g_thread_init(NULL);
 


### PR DESCRIPTION
I'm not clear on the divide between osxfuse/sshfs and libfuse/sshfs, but this
patch is necessary to fix a glib warning on OS X.