### PR TITLE
Forward file locking requests to the sftp server

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -527,6 +527,7 @@ static void cache_unity_fill(struct fuse_cache_operations *oper,
 	cache_oper->flag_nullpath_ok = oper->oper.flag_nullpath_ok;
 	cache_oper->flag_nopath  = oper->oper.flag_nopath;
 #endif
+	cache_oper->flock = oper->oper.flock;
 }
 
 static void cache_fill(struct fuse_cache_operations *oper,


### PR DESCRIPTION
This patch intercepts flock(2) system calls and forwards them to the remote host. The SFTP protocol extension is documented at https://github.com/openssh/openssh-portable/pull/66 .
Do not merge this pull request until the protocol is finalized by being merged into openssh.