### PR TITLE
Removed nonempty option from man page

### DIFF
--- a/sshfs.1.in
+++ b/sshfs.1.in
@@ -180,9 +180,6 @@ allow access to other users
 .TP
 \fB\-o\fR allow_root
 allow access to root
-.TP
-\fB\-o\fR nonempty
-allow mounts over non\-empty file/dir
 .HP
 \fB\-o\fR default_permissions
 enable permission checking by kernel


### PR DESCRIPTION
The nonempty mount option hasn't been suported since libfuse < 3.0.0.
As sshfs links against libfuse 3.1.0, this man page entry is obsolete.