### PR TITLE
Removed obsolete options from man page and FAQ

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -6,30 +6,26 @@ SSHFS FAQ
 2.     Advantage of sshfs over NFS and Samba
 3.     Create the device node
 4.     mv fails with "Operation not permitted"
-5.     cvs fails with "cvs [status aborted]: cannot get working
-       directory: No such file or directory" in a sshfs mounted directory
-6.     Changes on the server are not immediately visible in the
-       mounted directory.
-7.     Configuring the ssh connection
-8.     What are the no_readahead and sshfs_sync options for?
-9.    Why does df return strange values on partitions mounted via
+5.     Configuring the ssh connection
+6.     What are the no_readahead and sshfs_sync options for?
+7.     Why does df return strange values on partitions mounted via
        sshfs?
-10.    How do I specify the remote mount point (since the example
+8.     How do I specify the remote mount point (since the example
        defaults to the home directory)
-11.    sshfs hangs after a while
-12.    Following symlinks on the server side
-13.    Making absolute symlinks work
-14.    Mounting as root
-15.    Exporting via NFS
-16.    Automatical mounting using /etc/fstab
-17.    Why does SVN (etc...) fail with permission denied?
-18.    Why does SVN (etc...) fail to rename files?
-19.    Is there some neat way to do it in reverse?
-20.    Might it be reasonable to disallow loops?
-21.    How to mount through an intermediary ssh server, eg:
+9.     sshfs hangs after a while
+10.    Following symlinks on the server side
+11.    Making absolute symlinks work
+12.    Mounting as root
+13.    Exporting via NFS
+14.    Automatical mounting using /etc/fstab
+15.    Why does SVN (etc...) fail with permission denied?
+16.    Why does SVN (etc...) fail to rename files?
+17.    Is there some neat way to do it in reverse?
+18.    Might it be reasonable to disallow loops?
+19.    How to mount through an intermediary ssh server, eg:
        localhost -> A -> B; mount B from localhost
-22.    Alternative Solution
-23.    I seem to have successfully mounted a remote directory, but
+20.    Alternative Solution
+21.    I seem to have successfully mounted a remote directory, but
        performing an `ls -l` on the directory above the mount point shows
        the mount point's attributes as `? ? ? ? ? ?`. Nothing shows up in
        the directory either. What am I doing wrong?
@@ -82,80 +78,63 @@ SSHFS FAQ
 
    Use -o workaround=rename (requires sshfs version >= 1.3).
 
-5. cvs fails with "cvs status aborted?: cannot get working directory: No such
-   file or directory" in a sshfs mounted directory
-
-   Use the -oreaddir_ino option. Example:
-     sshfs -oreaddir_ino hostname:remote_dir mount_point
-
-6. Changes on the server are not immediately visible in the mounted directory.
-
-   By default, sshfs caches things for 20 seconds, use -o cache_timeout=N
-   to change the default cache timeout (in seconds) or -o cache=no for
-   disabling the cache.
-
-   You can also control cache timeouts for directory listing etc with
-   -o cache_stat_timeout=N,
-   -o cache_dir_timout=N, and
-   -o cache_link_timout=N.
-
-7. Configuring the ssh connection
+5. Configuring the ssh connection
 
    In addition to flags like -C, -p, and -o SSHOPT...=, you may find it
    easier to edit your /.ssh/config file. You can add an entry with any
    customization you want, test it with ssh, and finally use it with
    sshfs. As a bonus, you get a short mnemonic for your configuration.
 
-8. What are the no_readahead and sshfs_sync options for?
+6. What are the no_readahead and sshfs_sync options for?
 
    These disable read and write optimizations respectively. They don't
    really make sense unless you're doing something special.
 
-9. Why does df return strange values on partitions mounted via sshfs?
+7. Why does df return strange values on partitions mounted via sshfs?
 
    Because the SFTP protocol doesn't have a statfs operation this is
    currently not possible to display proper usage on remote partition.
 
-10. How do I specfy the remote mount point (since the example defaults to the
-    home directory)
+8. How do I specfy the remote mount point (since the example defaults to the
+   home directory)
 
-    The example shows:
-      sshfs hostname: mountpoint
+   The example shows:
+     sshfs hostname: mountpoint
 
-    To specify a remote mount point use:
-      sshfs hostname:remotemountpoint mountpoint
+   To specify a remote mount point use:
+     sshfs hostname:remotemountpoint mountpoint
 
-    This might be obvious to others, but I ended up looking up the
-    interface to sftp to see if I could learn how to specify the remote
-    mount point, then thought about the way that scp specifies the remote
-    directory, and it worked.
+   This might be obvious to others, but I ended up looking up the
+   interface to sftp to see if I could learn how to specify the remote
+   mount point, then thought about the way that scp specifies the remote
+   directory, and it worked.
 
-11. sshfs hangs after a while
+9. sshfs hangs after a while
 
-    Mounting works fine, I can use the files in Mountpoint as good as any
-    other files on my system, but after bit of time, changing nothing on
-    the remote files sshfs crashes. This means, I can not cd into the
-    Mountpoint (xterm hangs, nautilus hangs... every program trying to
-    access the Mountpoint gets stuck, and won't return).
+   Mounting works fine, I can use the files in Mountpoint as good as any
+   other files on my system, but after bit of time, changing nothing on
+   the remote files sshfs crashes. This means, I can not cd into the
+   Mountpoint (xterm hangs, nautilus hangs... every program trying to
+   access the Mountpoint gets stuck, and won't return).
 
-    Solution: add
-      ServerAliveInterval 15
+   Solution: add
+     ServerAliveInterval 15
 
-    in your .ssh/config (or use -o ServerAliveInterval=15 on the sshfs
-    command line but I did not test that solution). This will force the
-    ssh connection to stay alive even if you have no activity.
+   in your .ssh/config (or use -o ServerAliveInterval=15 on the sshfs
+   command line but I did not test that solution). This will force the
+   ssh connection to stay alive even if you have no activity.
 
-12. Following symlinks on the server side
+10. Following symlinks on the server side
 
     The -o follow_symlinks option will enable this.
 
-13. Making absolute symlinks work
+11. Making absolute symlinks work
 
     Use the -o transform_symlinks option, which will transform absolute
     symlinks (ones which point somewhere inside the mount) into relative
     ones.
 
-14. Mounting as root
+12. Mounting as root
 
     Generally it's not possible to use an sshfs mount as a "real"
     filesystem shared between multiple users. Some of this functionality
@@ -163,11 +142,11 @@ SSHFS FAQ
     options, but files will not be created with the correct ownership,
     etc...
 
-15. Exporting via NFS
+13. Exporting via NFS
 
     Use the userspace NFS daemon http://sourceforge.net/projects/unfs
 
-16. Automatical mounting using /etc/fstab
+14. Automatical mounting using /etc/fstab
 
     A line in /etc/fstab has the following format:
       sshfs#USERNAME@REMOTE_HOST:REMOTE_PATH MOUNT_POINT fuse SSHFS_OPTIONS 0 0
@@ -176,7 +155,7 @@ SSHFS FAQ
       sshfs#guest@guest.login.com:data /mnt/guest fuse \
         uid=1003,gid=100,umask=0,allow_other 0 0
 
-17. Why does SVN (etc...) fail with permission denied?
+15. Why does SVN (etc...) fail with permission denied?
 
     This is a bug that happens when an application creates a read-only
     file opened for writing (e.g. open("foo", O_WRONLY|O_CREAT, 0444))
@@ -184,7 +163,7 @@ SSHFS FAQ
     It has been fixed in sshfs version 1.3, but also requires FUSE version
     >=2.5.X and Linux kernel version >=2.6.15.
 
-18. Why does SVN (etc...) fail to rename files?
+16. Why does SVN (etc...) fail to rename files?
 
     $ svn co svn://anonsvn.kde.org/home/kde/trunk/KDE/kdelibs
     svn: Can't move 'kdelibs/.svn/tmp/entries' to 'kdelibs/.svn/entries':
@@ -200,7 +179,7 @@ SSHFS FAQ
     semantics, but it cannot guarantee atomicity. In most of the cases
     this doesn't matter, and things will work fine with this option.
 
-19. Is there some neat way to do it in reverse?
+17. Is there some neat way to do it in reverse?
 
     You want to mount a USB thumb drive onto a file server that is rather
     remote.
@@ -214,13 +193,13 @@ SSHFS FAQ
     (Now, is there is there a smarter way that does not involve port
     opening login permissions in an undesireable direction?)
 
-20. Might it be reasonable to disallow loops?
+18. Might it be reasonable to disallow loops?
 
     sshfs localhost:/mnt /mnt
 
     This seems to produce undesirable results. --JoshuaRodman
 
-21. How to mount through an intermediary ssh server, eg: localhost -> A -> B;
+19. How to mount through an intermediary ssh server, eg: localhost -> A -> B;
     mount B from localhost
 
     Start by mounting the folder you need that is on "a" to a folder on
@@ -230,7 +209,7 @@ SSHFS FAQ
     A mounts B:/home/x on /mnt/Bx
     localhost mounts A:/mnt/Bx on ~/mydir
 
-22. Alternative Solution:
+20. Alternative Solution:
 
     1) Create a shell script to wrap the tunneling of one ssh command over
     another,
@@ -244,7 +223,7 @@ SSHFS FAQ
     normal but using this script as the ssh command.
       $ sshfs -o ssh_command='Atunnel' B: ~/mydir
 
-23. I seem to have successfully mounted a remote directory, but performing an
+21. I seem to have successfully mounted a remote directory, but performing an
     `ls -l` on the directory above the mount point shows the mount point's
     attributes as `? ? ? ? ? ?`. Nothing shows up in the directory either. What
     am I doing wrong?

--- a/sshfs.1.in
+++ b/sshfs.1.in
@@ -64,24 +64,12 @@ synchronous readdir
 \fB\-o\fR sshfs_debug
 print some debugging information
 .TP
-\fB\-o\fR cache=BOOL
-enable caching {yes,no} (default: yes)
-.TP
-\fB\-o\fR cache_timeout=N
-sets timeout for caches in seconds (default: 20)
-.TP
-\fB\-o\fR cache_X_timeout=N
-sets timeout for {stat,dir,link} cache
-.TP
 \fB\-o\fR workaround=LIST
 colon separated list of workarounds
 .RS 8
 .TP
 none
 no workarounds enabled
-.TP
-all
-all workarounds enabled
 .TP
 [no]rename
 fix renaming to existing file (default: off)
@@ -180,9 +168,6 @@ allow access to other users
 .TP
 \fB\-o\fR allow_root
 allow access to root
-.TP
-\fB\-o\fR nonempty
-allow mounts over non\-empty file/dir
 .HP
 \fB\-o\fR default_permissions
 enable permission checking by kernel
@@ -193,23 +178,8 @@ set filesystem name
 \fB\-o\fR subtype=NAME
 set filesystem type
 .TP
-\fB\-o\fR large_read
-issue large read requests (2.4 only)
-.TP
 \fB\-o\fR max_read=N
 set maximum size of read requests
-.TP
-\fB\-o\fR hard_remove
-immediate removal (don't hide files)
-.TP
-\fB\-o\fR use_ino
-let filesystem set inode numbers
-.TP
-\fB\-o\fR readdir_ino
-try to fill in d_ino in readdir
-.TP
-\fB\-o\fR direct_io
-use direct I/O
 .TP
 \fB\-o\fR kernel_cache
 cache files in kernel
@@ -238,26 +208,11 @@ cache timeout for attributes (1.0s)
 \fB\-o\fR ac_attr_timeout=T
 auto cache timeout for attributes (attr_timeout)
 .TP
-\fB\-o\fR intr
-allow requests to be interrupted
-.TP
-\fB\-o\fR intr_signal=NUM
-signal to send on interrupt (10)
-.TP
 \fB\-o\fR modules=M1[:M2...]
 names of modules to push onto filesystem stack
 .TP
 \fB\-o\fR max_write=N
 set maximum size of write requests
-.TP
-\fB\-o\fR max_readahead=N
-set maximum readahead
-.TP
-\fB\-o\fR async_read
-perform reads asynchronously (default)
-.TP
-\fB\-o\fR sync_read
-perform reads synchronously
 .SS "Module options:"
 .TP
 [subdir]


### PR DESCRIPTION
I removed all obsolete options I could find (see #69).
I did this by simply trying out all options mentioned in the man page (except for the module ones).
All options that gave an error such as
```
fuse: unknown option(s): `-o OPTION'
```
were removed.

I think there might be a few options that were added since then which are not in the man page. I tried to create a list of them, but it wasn't clear to me which options were actually usable (and what they do), so I left it out. However,
```
sshfs --help
```
does print a list of supported options, which appears to be created by combing a static string and some function calls to libfuse functions (which in turn print some static strings).
Maybe these should be integrated into the man page?