### PR TITLE
Fix illegal options -u and --preserve on Mac OS X. 

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ test_scripts = [ 'conftest.py', 'pytest.ini', 'test_sshfs.py',
                  'util.py' ]
 custom_target('test_scripts', input: test_scripts,
               output: test_scripts, build_by_default: true,
-              command: ['cp', '-fP', '--preserve=mode',
+              command: ['cp', '-fPp',
                         '@INPUT@', meson.current_build_dir() ])
 
 # Provide something helpful when running 'ninja test'

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ test_scripts = [ 'conftest.py', 'pytest.ini', 'test_sshfs.py',
                  'util.py' ]
 custom_target('test_scripts', input: test_scripts,
               output: test_scripts, build_by_default: true,
-              command: ['cp', '-fPu', '--preserve=mode',
+              command: ['cp', '-fP', '--preserve=mode',
                         '@INPUT@', meson.current_build_dir() ])
 
 # Provide something helpful when running 'ninja test'


### PR DESCRIPTION
This fixes #97. I cherry-picked your commit 586ad6 to fix the -u, and added my own commit to replace --preserve with -p, which works with both GNU and BSD cp.

  ```
          -p    Cause cp to preserve the following attributes of each source file
           in the copy: modification time, access time, file flags, file mode,
           user ID, and group ID, as allowed by permissions.  Access Control
           Lists (ACLs) and Extended Attributes (EAs), including resource
           forks, will also be preserved.

           If the user ID and group ID cannot be preserved, no error message
           is displayed and the exit value is not altered.

           If the source file has its set-user-ID bit on and the user ID can-
           not be preserved, the set-user-ID bit is not preserved in the
           copy's permissions.  If the source file has its set-group-ID bit on
           and the group ID cannot be preserved, the set-group-ID bit is not
           preserved in the copy's permissions.  If the source file has both
           its set-user-ID and set-group-ID bits on, and either the user ID or
           group ID cannot be preserved, neither the set-user-ID nor set-
           group-ID bits are preserved in the copy's permissions.
```

For GNU cp, -p is equivalent to --preserve=mode,ownership,timestamps, which I am assuming is an acceptable addition.
