### PR TITLE
Fix memory leak on opendir error

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -2152,7 +2152,8 @@ static int sshfs_opendir(const char *path, struct fuse_file_info *fi)
 	if (!err) {
 		buf_finish(handle);
 		fi->fh = (unsigned long) handle;
-	}
+	} else
+		free(handle);
 	buf_free(&buf);
 	return err;
 }


### PR DESCRIPTION
buf_free(handle) is not necessary/possible before the free(handle) as buf_init is called at the end of sftp_request_wait, just before it succeeds.
