### PR TITLE
Parallel connections

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -1756,8 +1756,9 @@ static struct conn *choose_conn()
 {
 	int best_index = 0;
 	uint64_t best_score = ~0ULL; /* smaller is better */
+	int i;
 
-	for (int i = 0; i < sshfs.max_conns; i++) {
+	for (i = 0; i < sshfs.max_conns; i++) {
 		uint64_t score = ((uint64_t) sshfs.conns[i].req_count << 43) +
 				 ((uint64_t) sshfs.conns[i].dir_count << 22) +
 				 ((uint64_t) sshfs.conns[i].file_count << 1) +
@@ -3401,10 +3402,12 @@ static int sshfs_truncate_workaround(const char *path, off_t size,
 
 static int processing_init(void)
 {
+	int i;
+
 	signal(SIGPIPE, SIG_IGN);
 
 	pthread_mutex_init(&sshfs.lock, NULL);
-	for (int i = 0; i < sshfs.max_conns; i++)
+	for (i = 0; i < sshfs.max_conns; i++)
 		pthread_mutex_init(&sshfs.conns[i].lock_write, NULL);
 	pthread_cond_init(&sshfs.outstanding_cond, NULL);
 	sshfs.reqtab = g_hash_table_new(NULL, NULL);
@@ -3950,6 +3953,7 @@ int main(int argc, char *argv[])
 	const char *sftp_server;
 	struct fuse *fuse;
 	struct fuse_session *se;
+	int i;
 
 #ifdef __APPLE__
 	if (!realpath(*exec_path, sshfs_program_path)) {
@@ -4090,7 +4094,7 @@ int main(int argc, char *argv[])
 	}
 
 	sshfs.conns = g_new0(struct conn, sshfs.max_conns);
-	for (int i = 0; i < sshfs.max_conns; i++) {
+	for (i = 0; i < sshfs.max_conns; i++) {
 		sshfs.conns[i].rfd = -1;
 		sshfs.conns[i].wfd = -1;
 	}

--- a/sshfs.c
+++ b/sshfs.c
@@ -142,10 +142,26 @@
 static char sshfs_program_path[PATH_MAX] = { 0 };
 #endif /* __APPLE__ */
 
+struct conn {
+	pthread_mutex_t lock_write;
+	int processing_thread_started;
+	int rfd;
+	int wfd;
+	int connver;
+	int req_count;
+	int dir_count;
+	int file_count;
+};
+
 struct buffer {
 	uint8_t *p;
 	size_t len;
 	size_t size;
+};
+
+struct dir_handle {
+	struct buffer buf;
+	struct conn *conn;
 };
 
 struct list_head {
@@ -169,6 +185,7 @@ struct request {
 	request_func end_func;
 	size_t len;
 	struct list_head list;
+	struct conn *conn;
 };
 
 struct sshfs_io {
@@ -202,6 +219,7 @@ struct sshfs_file {
 	struct read_chunk *readahead;
 	off_t next_pos;
 	int is_seq;
+	struct conn *conn;
 	int connver;
 	int modifver;
 	int refs;
@@ -251,14 +269,12 @@ struct sshfs {
 	char *base_path;
 	GHashTable *reqtab;
 	pthread_mutex_t lock;
-	pthread_mutex_t lock_write;
-	int processing_thread_started;
 	unsigned int randseed;
-	int rfd;
-	int wfd;
+	int max_conns;
+	struct conn *conns;
 	int ptyfd;
 	int ptyslavefd;
-	int connver;
+	int connvers;
 	int server_version;
 	unsigned remote_uid;
 	unsigned local_uid;
@@ -407,6 +423,7 @@ static struct fuse_opt sshfs_opts[] = {
 	SSHFS_OPT("disable_hardlink",  disable_hardlink, 1),
 	SSHFS_OPT("dir_cache=yes", dir_cache, 1),
 	SSHFS_OPT("dir_cache=no",  dir_cache, 0),
+	SSHFS_OPT("max_conns=%u",  max_conns, 1),
 
 	SSHFS_OPT("-h",		show_help, 1),
 	SSHFS_OPT("--help",	show_help, 1),
@@ -899,7 +916,7 @@ static void ssh_add_arg(const char *arg)
 }
 
 
-static int pty_expect_loop(void)
+static int pty_expect_loop(struct conn *conn)
 {
 	int res;
 	char buf[256];
@@ -912,7 +929,7 @@ static int pty_expect_loop(void)
 	while (1) {
 		struct pollfd fds[2];
 
-		fds[0].fd = sshfs.rfd;
+		fds[0].fd = conn->rfd;
 		fds[0].events = POLLIN;
 		fds[1].fd = sshfs.ptyfd;
 		fds[1].events = POLLIN;
@@ -999,7 +1016,7 @@ static void replace_arg(char **argp, const char *newarg)
 	}
 }
 
-static int start_ssh(void)
+static int start_ssh(struct conn *conn)
 {
 	char *ptyname = NULL;
 	int sockpair[2];
@@ -1020,8 +1037,8 @@ static int start_ssh(void)
 		perror("failed to create socket pair");
 		return -1;
 	}
-	sshfs.rfd = sockpair[0];
-	sshfs.wfd = sockpair[0];
+	conn->rfd = sockpair[0];
+	conn->wfd = sockpair[0];
 
 	pid = fork();
 	if (pid == -1) {
@@ -1089,14 +1106,14 @@ static int start_ssh(void)
 	return 0;
 }
 
-static int connect_slave()
+static int connect_slave(struct conn *conn)
 {
-	sshfs.rfd = STDIN_FILENO;
-	sshfs.wfd = STDOUT_FILENO;
+	conn->rfd = STDIN_FILENO;
+	conn->wfd = STDOUT_FILENO;
 	return 0;
 }
 
-static int connect_to(char *host, char *port)
+static int connect_to(struct conn *conn, char *host, char *port)
 {
 	int err;
 	int sock;
@@ -1130,16 +1147,16 @@ static int connect_to(char *host, char *port)
 
 	freeaddrinfo(ai);
 
-	sshfs.rfd = sock;
-	sshfs.wfd = sock;
+	conn->rfd = sock;
+	conn->wfd = sock;
 	return 0;
 }
 
-static int do_write(struct iovec *iov, size_t count)
+static int do_write(struct conn *conn, struct iovec *iov, size_t count)
 {
 	int res;
 	while (count) {
-		res = writev(sshfs.wfd, iov, count);
+		res = writev(conn->wfd, iov, count);
 		if (res == -1) {
 			perror("write");
 			return -1;
@@ -1186,8 +1203,8 @@ static size_t iov_length(const struct iovec *iov, unsigned long nr_segs)
 
 #define SFTP_MAX_IOV 3
 
-static int sftp_send_iov(uint8_t type, uint32_t id, struct iovec iov[],
-                         size_t count)
+static int sftp_send_iov(struct conn *conn, uint8_t type, uint32_t id,
+                         struct iovec iov[], size_t count)
 {
 	int res;
 	struct buffer buf;
@@ -1203,20 +1220,20 @@ static int sftp_send_iov(uint8_t type, uint32_t id, struct iovec iov[],
 	buf_to_iov(&buf, &iovout[nout++]);
 	for (i = 0; i < count; i++)
 		iovout[nout++] = iov[i];
-	pthread_mutex_lock(&sshfs.lock_write);
-	res = do_write(iovout, nout);
-	pthread_mutex_unlock(&sshfs.lock_write);
+	pthread_mutex_lock(&conn->lock_write);
+	res = do_write(conn, iovout, nout);
+	pthread_mutex_unlock(&conn->lock_write);
 	buf_free(&buf);
 	return res;
 }
 
-static int do_read(struct buffer *buf)
+static int do_read(struct conn *conn, struct buffer *buf)
 {
 	int res;
 	uint8_t *p = buf->p;
 	size_t size = buf->size;
 	while (size) {
-		res = read(sshfs.rfd, p, size);
+		res = read(conn->rfd, p, size);
 		if (res == -1) {
 			perror("read");
 			return -1;
@@ -1230,13 +1247,13 @@ static int do_read(struct buffer *buf)
 	return 0;
 }
 
-static int sftp_read(uint8_t *type, struct buffer *buf)
+static int sftp_read(struct conn *conn, uint8_t *type, struct buffer *buf)
 {
 	int res;
 	struct buffer buf2;
 	uint32_t len;
 	buf_init(&buf2, 5);
-	res = do_read(&buf2);
+	res = do_read(conn, &buf2);
 	if (res != -1) {
 		if (buf_get_uint32(&buf2, &len) == -1)
 			return -1;
@@ -1247,7 +1264,7 @@ static int sftp_read(uint8_t *type, struct buffer *buf)
 		if (buf_get_uint8(&buf2, type) == -1)
 			return -1;
 		buf_init(buf, len - 1);
-		res = do_read(buf);
+		res = do_read(conn, buf);
 	}
 	buf_free(&buf2);
 	return res;
@@ -1255,6 +1272,7 @@ static int sftp_read(uint8_t *type, struct buffer *buf)
 
 static void request_free(struct request *req)
 {
+	req->conn->req_count--;
 	buf_free(&req->reply);
 	sem_destroy(&req->ready);
 	g_free(req);
@@ -1289,9 +1307,12 @@ static void chunk_put_locked(struct read_chunk *chunk)
 	pthread_mutex_unlock(&sshfs.lock);
 }
 
-static int clean_req(void *key_, struct request *req)
+static int clean_req(void *key_, struct request *req, struct conn *conn)
 {
 	(void) key_;
+
+	if (req->conn != conn)
+		return FALSE;
 
 	req->error = -EIO;
 	if (req->want_reply)
@@ -1304,7 +1325,7 @@ static int clean_req(void *key_, struct request *req)
 	return TRUE;
 }
 
-static int process_one_request(void)
+static int process_one_request(struct conn *conn)
 {
 	int res;
 	struct buffer buf;
@@ -1313,7 +1334,7 @@ static int process_one_request(void)
 	uint32_t id;
 
 	buf_init(&buf, 0);
-	res = sftp_read(&type, &buf);
+	res = sftp_read(conn, &type, &buf);
 	if (res == -1)
 		return -1;
 	if (buf_get_uint32(&buf, &id) == -1)
@@ -1375,13 +1396,13 @@ static int process_one_request(void)
 	return 0;
 }
 
-static void close_conn(void)
+static void close_conn(struct conn *conn)
 {
-	close(sshfs.rfd);
-	if (sshfs.rfd != sshfs.wfd)
-		close(sshfs.wfd);
-	sshfs.rfd = -1;
-	sshfs.wfd = -1;
+	close(conn->rfd);
+	if (conn->rfd != conn->wfd)
+		close(conn->wfd);
+	conn->rfd = -1;
+	conn->wfd = -1;
 	if (sshfs.ptyfd != -1) {
 		close(sshfs.ptyfd);
 		sshfs.ptyfd = -1;
@@ -1395,17 +1416,18 @@ static void close_conn(void)
 static void *process_requests(void *data_)
 {
 	(void) data_;
+	struct conn *conn = data_;
 
 	while (1) {
-		if (process_one_request() == -1)
+		if (process_one_request(conn) == -1)
 			break;
 	}
 
 	pthread_mutex_lock(&sshfs.lock);
-	sshfs.processing_thread_started = 0;
-	close_conn();
-	g_hash_table_foreach_remove(sshfs.reqtab, (GHRFunc) clean_req, NULL);
-	sshfs.connver ++;
+	conn->processing_thread_started = 0;
+	close_conn(conn);
+	g_hash_table_foreach_remove(sshfs.reqtab, (GHRFunc) clean_req, conn);
+	conn->connver = ++sshfs.connvers;
 	sshfs.outstanding_len = 0;
 	pthread_cond_broadcast(&sshfs.outstanding_cond);
 	pthread_mutex_unlock(&sshfs.lock);
@@ -1417,7 +1439,8 @@ static void *process_requests(void *data_)
 	return NULL;
 }
 
-static int sftp_init_reply_ok(struct buffer *buf, uint32_t *version)
+static int sftp_init_reply_ok(struct conn *conn, struct buffer *buf,
+                              uint32_t *version)
 {
 	uint32_t len;
 	uint8_t type;
@@ -1443,7 +1466,7 @@ static int sftp_init_reply_ok(struct buffer *buf, uint32_t *version)
 		struct buffer buf2;
 
 		buf_init(&buf2, len - 5);
-		if (do_read(&buf2) == -1) {
+		if (do_read(conn, &buf2) == -1) {
 			buf_free(&buf2);
 			return -1;
 		}
@@ -1480,17 +1503,17 @@ static int sftp_init_reply_ok(struct buffer *buf, uint32_t *version)
 	return 0;
 }
 
-static int sftp_find_init_reply(uint32_t *version)
+static int sftp_find_init_reply(struct conn *conn, uint32_t *version)
 {
 	int res;
 	struct buffer buf;
 
 	buf_init(&buf, 9);
-	res = do_read(&buf);
+	res = do_read(conn, &buf);
 	while (res != -1) {
 		struct buffer buf2;
 
-		res = sftp_init_reply_ok(&buf, version);
+		res = sftp_init_reply_ok(conn, &buf, version);
 		if (res <= 0)
 			break;
 
@@ -1500,25 +1523,25 @@ static int sftp_find_init_reply(uint32_t *version)
 		buf.len = 0;
 		buf2.p = buf.p + buf.size - 1;
 		buf2.size = 1;
-		res = do_read(&buf2);
+		res = do_read(conn, &buf2);
 	}
 	buf_free(&buf);
 	return res;
 }
 
-static int sftp_init()
+static int sftp_init(struct conn *conn)
 {
 	int res = -1;
 	uint32_t version = 0;
 	struct buffer buf;
 	buf_init(&buf, 0);
-	if (sftp_send_iov(SSH_FXP_INIT, PROTO_VERSION, NULL, 0) == -1)
+	if (sftp_send_iov(conn, SSH_FXP_INIT, PROTO_VERSION, NULL, 0) == -1)
 		goto out;
 
-	if (sshfs.password_stdin && pty_expect_loop() == -1)
+	if (sshfs.password_stdin && pty_expect_loop(conn) == -1)
 		goto out;
 
-	if (sftp_find_init_reply(&version) == -1)
+	if (sftp_find_init_reply(conn, &version) == -1)
 		goto out;
 
 	sshfs.server_version = version;
@@ -1549,7 +1572,7 @@ static int sftp_error_to_errno(uint32_t error)
 	}
 }
 
-static void sftp_detect_uid()
+static void sftp_detect_uid(struct conn *conn)
 {
 	int flags;
 	uint32_t id = sftp_get_id();
@@ -1562,10 +1585,10 @@ static void sftp_detect_uid()
 	buf_init(&buf, 5);
 	buf_add_string(&buf, ".");
 	buf_to_iov(&buf, &iov[0]);
-	if (sftp_send_iov(SSH_FXP_STAT, id, iov, 1) == -1)
+	if (sftp_send_iov(conn, SSH_FXP_STAT, id, iov, 1) == -1)
 		goto out;
 	buf_clear(&buf);
-	if (sftp_read(&type, &buf) == -1)
+	if (sftp_read(conn, &type, &buf) == -1)
 		goto out;
 	if (type != SSH_FXP_ATTRS && type != SSH_FXP_STATUS) {
 		fprintf(stderr, "protocol error\n");
@@ -1607,7 +1630,7 @@ out:
 	buf_free(&buf);
 }
 
-static int sftp_check_root(const char *base_path)
+static int sftp_check_root(struct conn *conn, const char *base_path)
 {
 	int flags;
 	uint32_t id = sftp_get_id();
@@ -1622,10 +1645,10 @@ static int sftp_check_root(const char *base_path)
 	buf_init(&buf, 0);
 	buf_add_string(&buf, remote_dir);
 	buf_to_iov(&buf, &iov[0]);
-	if (sftp_send_iov(SSH_FXP_LSTAT, id, iov, 1) == -1)
+	if (sftp_send_iov(conn, SSH_FXP_LSTAT, id, iov, 1) == -1)
 		goto out;
 	buf_clear(&buf);
-	if (sftp_read(&type, &buf) == -1)
+	if (sftp_read(conn, &type, &buf) == -1)
 		goto out;
 	if (type != SSH_FXP_ATTRS && type != SSH_FXP_STATUS) {
 		fprintf(stderr, "protocol error\n");
@@ -1670,45 +1693,45 @@ out:
 	return err;
 }
 
-static int connect_remote(void)
+static int connect_remote(struct conn *conn)
 {
 	int err;
 
 	if (sshfs.slave)
-		err = connect_slave();
+		err = connect_slave(conn);
 	else if (sshfs.directport)
-		err = connect_to(sshfs.host, sshfs.directport);
+		err = connect_to(conn, sshfs.host, sshfs.directport);
 	else
-		err = start_ssh();
+		err = start_ssh(conn);
 	if (!err)
-		err = sftp_init();
+		err = sftp_init(conn);
 
 	if (err)
-		close_conn();
+		close_conn(conn);
 	else
 		sshfs.num_connect++;
 
 	return err;
 }
 
-static int start_processing_thread(void)
+static int start_processing_thread(struct conn *conn)
 {
 	int err;
 	pthread_t thread_id;
 	sigset_t oldset;
 	sigset_t newset;
 
-	if (sshfs.processing_thread_started)
+	if (conn->processing_thread_started)
 		return 0;
 
-	if (sshfs.rfd == -1) {
-		err = connect_remote();
+	if (conn->rfd == -1) {
+		err = connect_remote(conn);
 		if (err)
 			return -EIO;
 	}
 
 	if (sshfs.detect_uid) {
-		sftp_detect_uid();
+		sftp_detect_uid(conn);
 		sshfs.detect_uid = 0;
 	}
 
@@ -1718,15 +1741,34 @@ static int start_processing_thread(void)
 	sigaddset(&newset, SIGHUP);
 	sigaddset(&newset, SIGQUIT);
 	pthread_sigmask(SIG_BLOCK, &newset, &oldset);
-	err = pthread_create(&thread_id, NULL, process_requests, NULL);
+	err = pthread_create(&thread_id, NULL, process_requests, conn);
 	if (err) {
 		fprintf(stderr, "failed to create thread: %s\n", strerror(err));
 		return -EIO;
 	}
 	pthread_detach(thread_id);
 	pthread_sigmask(SIG_SETMASK, &oldset, NULL);
-	sshfs.processing_thread_started = 1;
+	conn->processing_thread_started = 1;
 	return 0;
+}
+
+static struct conn *choose_conn()
+{
+	int best_index = 0;
+	uint64_t best_score = ~0ULL; /* smaller is better */
+
+	for (int i = 0; i < sshfs.max_conns; i++) {
+		uint64_t score = ((uint64_t) sshfs.conns[i].req_count << 43) +
+				 ((uint64_t) sshfs.conns[i].dir_count << 22) +
+				 ((uint64_t) sshfs.conns[i].file_count << 1) +
+				 (uint64_t) (sshfs.conns[i].rfd >= 0 ? 0 : 1);
+		if (score < best_score) {
+			best_index = i;
+			best_score = score;
+		}
+	}
+
+	return &sshfs.conns[best_index];
 }
 
 static void *sshfs_init(struct fuse_conn_info *conn,
@@ -1743,7 +1785,7 @@ static void *sshfs_init(struct fuse_conn_info *conn,
         conn->capable |= FUSE_CAP_EXPORT_SUPPORT;
 
 	if (!sshfs.delay_connect)
-		start_processing_thread();
+		start_processing_thread(&sshfs.conns[0]);
 
 	// SFTP only supports 1-second time resolution
 	conn->time_gran = 1000000000;
@@ -1817,10 +1859,11 @@ out:
 	return err;
 }
 
-static int sftp_request_send(uint8_t type, struct iovec *iov, size_t count,
-                             request_func begin_func, request_func end_func,
-                             int want_reply, void *data,
-                             struct request **reqp)
+static int sftp_request_send_ex(struct conn **connp, struct conn *conn,
+                                uint8_t type, struct iovec *iov, size_t count,
+                                request_func begin_func, request_func end_func,
+                                int want_reply, void *data,
+                                struct request **reqp)
 {
 	int err;
 	uint32_t id;
@@ -1836,7 +1879,11 @@ static int sftp_request_send(uint8_t type, struct iovec *iov, size_t count,
 		begin_func(req);
 	id = sftp_get_id();
 	req->id = id;
-	err = start_processing_thread();
+	if (conn == NULL)
+		conn = choose_conn();
+	req->conn = conn;
+	req->conn->req_count++;
+	err = start_processing_thread(conn);
 	if (err) {
 		pthread_mutex_unlock(&sshfs.lock);
 		goto out;
@@ -1856,7 +1903,7 @@ static int sftp_request_send(uint8_t type, struct iovec *iov, size_t count,
 	pthread_mutex_unlock(&sshfs.lock);
 
 	err = -EIO;
-	if (sftp_send_iov(type, id, iov, count) == -1) {
+	if (sftp_send_iov(conn, type, id, iov, count) == -1) {
 		gboolean rmed;
 
 		pthread_mutex_lock(&sshfs.lock);
@@ -1871,6 +1918,8 @@ static int sftp_request_send(uint8_t type, struct iovec *iov, size_t count,
 	}
 	if (want_reply)
 		*reqp = req;
+	if (connp)
+		*connp = conn;
 	return 0;
 
 out:
@@ -1883,28 +1932,60 @@ out:
 	return err;
 }
 
+static int sftp_request_send(struct conn *conn,
+                             uint8_t type, struct iovec *iov, size_t count,
+                             request_func begin_func, request_func end_func,
+                             int want_reply, void *data,
+                             struct request **reqp)
+{
+	return sftp_request_send_ex(NULL, conn, type, iov, count, begin_func,
+	                            end_func, want_reply, data, reqp);
+}
 
-static int sftp_request_iov(uint8_t type, struct iovec *iov, size_t count,
+static int sftp_request_iov(struct conn **connp, struct conn *conn,
+                            uint8_t type, struct iovec *iov, size_t count,
                             uint8_t expect_type, struct buffer *outbuf)
 {
 	int err;
 	struct request *req;
 
-	err = sftp_request_send(type, iov, count, NULL, NULL, expect_type, NULL,
-				&req);
+	err = sftp_request_send_ex(connp, conn, type, iov, count, NULL, NULL,
+				   expect_type, NULL, &req);
 	if (expect_type == 0)
 		return err;
 
 	return sftp_request_wait(req, type, expect_type, outbuf);
 }
 
-static int sftp_request(uint8_t type, const struct buffer *buf,
-                        uint8_t expect_type, struct buffer *outbuf)
+static int sftp_request_ex(struct conn **connp, struct conn *conn,
+                           uint8_t type, const struct buffer *buf,
+                           uint8_t expect_type, struct buffer *outbuf)
 {
 	struct iovec iov;
 
 	buf_to_iov(buf, &iov);
-	return sftp_request_iov(type, &iov, 1, expect_type, outbuf);
+	return sftp_request_iov(connp, conn, type, &iov, 1, expect_type,
+				outbuf);
+}
+
+static int sftp_request(uint8_t type, const struct buffer *buf,
+                        uint8_t expect_type, struct buffer *outbuf)
+{
+	return sftp_request_ex(NULL, NULL, type, buf, expect_type, outbuf);
+}
+
+static int sftp_request_with(struct conn *conn,
+                             uint8_t type, const struct buffer *buf,
+                             uint8_t expect_type, struct buffer *outbuf)
+{
+	return sftp_request_ex(NULL, conn, type, buf, expect_type, outbuf);
+}
+
+static int sftp_request_get_conn(struct conn **connp,
+                                 uint8_t type, const struct buffer *buf,
+                                 uint8_t expect_type, struct buffer *outbuf)
+{
+	return sftp_request_ex(connp, NULL, type, buf, expect_type, outbuf);
 }
 
 static int sshfs_access(const char *path, int mask)
@@ -2022,12 +2103,13 @@ static int sshfs_readlink(const char *path, char *linkbuf, size_t size)
 	return err;
 }
 
-static int sftp_readdir_send(struct request **req, struct buffer *handle)
+static int sftp_readdir_send(struct conn *conn, struct request **req,
+			     struct buffer *handle)
 {
 	struct iovec iov;
 
 	buf_to_iov(handle, &iov);
-	return sftp_request_send(SSH_FXP_READDIR, &iov, 1, NULL, NULL,
+	return sftp_request_send(conn, SSH_FXP_READDIR, &iov, 1, NULL, NULL,
 				 SSH_FXP_NAME, NULL, req);
 }
 
@@ -2039,8 +2121,8 @@ static int sshfs_req_pending(struct request *req)
 		return 0;
 }
 
-static int sftp_readdir_async(struct buffer *handle, void *buf, off_t offset,
-			     fuse_fill_dir_t filler)
+static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
+			      void *buf, off_t offset, fuse_fill_dir_t filler)
 {
 	int err = 0;
 	int outstanding = 0;
@@ -2056,7 +2138,7 @@ static int sftp_readdir_async(struct buffer *handle, void *buf, off_t offset,
 		int tmperr;
 
 		while (!done && outstanding < max) {
-			tmperr = sftp_readdir_send(&req, handle);
+			tmperr = sftp_readdir_send(conn, &req, handle);
 
 			if (tmperr && !done) {
 				err = tmperr;
@@ -2117,14 +2199,15 @@ static int sftp_readdir_async(struct buffer *handle, void *buf, off_t offset,
 	return err;
 }
 
-static int sftp_readdir_sync(struct buffer *handle, void *buf, off_t offset,
-			     fuse_fill_dir_t filler)
+static int sftp_readdir_sync(struct conn *conn, struct buffer *handle,
+			     void *buf, off_t offset, fuse_fill_dir_t filler)
 {
 	int err;
 	assert(offset == 0);
 	do {
 		struct buffer name;
-		err = sftp_request(SSH_FXP_READDIR, handle, SSH_FXP_NAME, &name);
+		err = sftp_request_with(conn, SSH_FXP_READDIR, handle,
+					SSH_FXP_NAME, &name);
 		if (!err) {
 			err = buf_get_entries(&name, buf, filler);
 			buf_free(&name);
@@ -2139,21 +2222,27 @@ static int sftp_readdir_sync(struct buffer *handle, void *buf, off_t offset,
 static int sshfs_opendir(const char *path, struct fuse_file_info *fi)
 {
 	int err;
+	struct conn *conn;
 	struct buffer buf;
-	struct buffer *handle;
+	struct dir_handle *handle;
 
-	handle = malloc(sizeof(struct buffer));
+	handle = g_new0(struct dir_handle, 1);
 	if(handle == NULL)
 		return -ENOMEM;
 
 	buf_init(&buf, 0);
 	buf_add_path(&buf, path);
-	err = sftp_request(SSH_FXP_OPENDIR, &buf, SSH_FXP_HANDLE, handle);
+	err = sftp_request_get_conn(&conn, SSH_FXP_OPENDIR, &buf,
+				    SSH_FXP_HANDLE, &handle->buf);
 	if (!err) {
-		buf_finish(handle);
+		buf_finish(&handle->buf);
+		pthread_mutex_lock(&sshfs.lock);
+		handle->conn = conn;
+		handle->conn->dir_count++;
+		pthread_mutex_unlock(&sshfs.lock);
 		fi->fh = (unsigned long) handle;
 	} else
-		free(handle);
+		g_free(handle);
 	buf_free(&buf);
 	return err;
 }
@@ -2164,14 +2253,16 @@ static int sshfs_readdir(const char *path, void *dbuf, fuse_fill_dir_t filler,
 {
 	(void) path; (void) flags;
 	int err;
-	struct buffer *handle;
+	struct dir_handle *handle;
 
-	handle = (struct buffer*) fi->fh;
+	handle = (struct dir_handle*) fi->fh;
 
 	if (sshfs.sync_readdir)
-		err = sftp_readdir_sync(handle, dbuf, offset, filler);
+		err = sftp_readdir_sync(handle->conn, &handle->buf, dbuf,
+					offset, filler);
 	else
-		err = sftp_readdir_async(handle, dbuf, offset, filler);
+		err = sftp_readdir_async(handle->conn, &handle->buf, dbuf,
+					 offset, filler);
 
 	return err;
 }
@@ -2180,12 +2271,16 @@ static int sshfs_releasedir(const char *path, struct fuse_file_info *fi)
 {
 	(void) path;
 	int err;
-	struct buffer *handle;
+	struct dir_handle *handle;
 
-	handle = (struct buffer*) fi->fh;
-	err = sftp_request(SSH_FXP_CLOSE, handle, 0, NULL);
-	buf_free(handle);
-	free(handle);
+	handle = (struct dir_handle*) fi->fh;
+	err = sftp_request_with(handle->conn, SSH_FXP_CLOSE, &handle->buf, 0,
+				NULL);
+	pthread_mutex_lock(&sshfs.lock);
+	handle->conn->dir_count--;
+	pthread_mutex_unlock(&sshfs.lock);
+	buf_free(&handle->buf);
+	g_free(handle);
 	return err;
 }
 
@@ -2206,6 +2301,7 @@ static int sshfs_mkdir(const char *path, mode_t mode)
 static int sshfs_mknod(const char *path, mode_t mode, dev_t rdev)
 {
 	int err;
+	struct conn *conn;
 	struct buffer buf;
 	struct buffer handle;
 	(void) rdev;
@@ -2218,12 +2314,13 @@ static int sshfs_mknod(const char *path, mode_t mode, dev_t rdev)
 	buf_add_uint32(&buf, SSH_FXF_WRITE | SSH_FXF_CREAT | SSH_FXF_EXCL);
 	buf_add_uint32(&buf, SSH_FILEXFER_ATTR_PERMISSIONS);
 	buf_add_uint32(&buf, mode);
-	err = sftp_request(SSH_FXP_OPEN, &buf, SSH_FXP_HANDLE, &handle);
+	err = sftp_request_get_conn(&conn, SSH_FXP_OPEN, &buf, SSH_FXP_HANDLE,
+				    &handle);
 	if (!err) {
 		int err2;
 		buf_finish(&handle);
-		err2 = sftp_request(SSH_FXP_CLOSE, &handle, SSH_FXP_STATUS,
-				    NULL);
+		err2 = sftp_request_with(conn, SSH_FXP_CLOSE, &handle,
+					 SSH_FXP_STATUS, NULL);
 		if (!err)
 			err = err2;
 		buf_free(&handle);
@@ -2360,7 +2457,7 @@ static inline int sshfs_file_is_conn(struct sshfs_file *sf)
 	int ret;
 
 	pthread_mutex_lock(&sshfs.lock);
-	ret = (sf->connver == sshfs.connver);
+	ret = (sf->connver == sf->conn->connver);
 	pthread_mutex_unlock(&sshfs.lock);
 
 	return ret;
@@ -2395,8 +2492,9 @@ static int sshfs_chmod(const char *path, mode_t mode,
 	buf_add_uint32(&buf, mode);
 	
 	/* FIXME: really needs LSETSTAT extension (debian Bug#640038) */
-	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
-			   &buf, SSH_FXP_STATUS, NULL);
+	err = sftp_request_with(sf == NULL ? NULL : sf->conn,
+				sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
+				&buf, SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
 	return err;
 }
@@ -2442,8 +2540,9 @@ static int sshfs_chown(const char *path, uid_t uid, gid_t gid,
 	buf_add_uint32(&buf, uid);
 	buf_add_uint32(&buf, gid);
 
-	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
-			   &buf, SSH_FXP_STATUS, NULL);
+	err = sftp_request_with(sf == NULL ? NULL : sf->conn,
+				sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
+				&buf, SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
 	return err;
 }
@@ -2481,8 +2580,9 @@ static int sshfs_utimens(const char *path, const struct timespec tv[2],
 	buf_add_uint32(&buf, tv[0].tv_sec);
 	buf_add_uint32(&buf, tv[1].tv_sec);
 
-	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
-			   &buf, SSH_FXP_STATUS, NULL);
+	err = sftp_request_with(sf == NULL ? NULL : sf->conn,
+				sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
+				&buf, SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
 	return err;
 }
@@ -2535,7 +2635,9 @@ static int sshfs_open_common(const char *path, mode_t mode,
 	sf->next_pos = 0;
 	pthread_mutex_lock(&sshfs.lock);
 	sf->modifver= sshfs.modifver;
-	sf->connver = sshfs.connver;
+	sf->conn = choose_conn();
+	sf->conn->file_count++;
+	sf->connver = sf->conn->connver;
 	pthread_mutex_unlock(&sshfs.lock);
 	buf_init(&buf, 0);
 	buf_add_path(&buf, path);
@@ -2543,12 +2645,12 @@ static int sshfs_open_common(const char *path, mode_t mode,
 	buf_add_uint32(&buf, SSH_FILEXFER_ATTR_PERMISSIONS);
 	buf_add_uint32(&buf, mode);
 	buf_to_iov(&buf, &iov);
-	sftp_request_send(SSH_FXP_OPEN, &iov, 1, NULL, NULL, 1, NULL,
+	sftp_request_send(sf->conn, SSH_FXP_OPEN, &iov, 1, NULL, NULL, 1, NULL,
 			  &open_req);
 	buf_clear(&buf);
 	buf_add_path(&buf, path);
 	type = sshfs.follow_symlinks ? SSH_FXP_STAT : SSH_FXP_LSTAT;
-	err2 = sftp_request(type, &buf, SSH_FXP_ATTRS, &outbuf);
+	err2 = sftp_request_with(sf->conn, type, &buf, SSH_FXP_ATTRS, &outbuf);
 	if (!err2) {
 		err2 = buf_get_attrs(&outbuf, &stbuf, NULL);
 		buf_free(&outbuf);
@@ -2557,7 +2659,8 @@ static int sshfs_open_common(const char *path, mode_t mode,
 				&sf->handle);
 	if (!err && err2) {
 		buf_finish(&sf->handle);
-		sftp_request(SSH_FXP_CLOSE, &sf->handle, 0, NULL);
+		sftp_request_with(sf->conn, SSH_FXP_CLOSE, &sf->handle, 0,
+				  NULL);
 		buf_free(&sf->handle);
 		err = err2;
 	}
@@ -2570,6 +2673,9 @@ static int sshfs_open_common(const char *path, mode_t mode,
 	} else {
 		if (sshfs.dir_cache)
 			cache_invalidate(path);
+		pthread_mutex_lock(&sshfs.lock);
+		sf->conn->file_count--;
+		pthread_mutex_unlock(&sshfs.lock);
 		g_free(sf);
 	}
 	buf_free(&buf);
@@ -2628,7 +2734,8 @@ static int sshfs_fsync(const char *path, int isdatasync,
 	buf_init(&buf, 0);
 	buf_add_string(&buf, SFTP_EXT_FSYNC);
 	buf_add_buf(&buf, &sf->handle);
-	err = sftp_request(SSH_FXP_EXTENDED, &buf, SSH_FXP_STATUS, NULL);
+	err = sftp_request_with(sf->conn, SSH_FXP_EXTENDED, &buf,
+				SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
 	return err;
 }
@@ -2636,8 +2743,12 @@ static int sshfs_fsync(const char *path, int isdatasync,
 static void sshfs_file_put(struct sshfs_file *sf)
 {
 	sf->refs--;
-	if (!sf->refs)
+	if (!sf->refs) {
+		pthread_mutex_lock(&sshfs.lock);
+		sf->conn->file_count--;
+		pthread_mutex_unlock(&sshfs.lock);
 		g_free(sf);
+	}
 }
 
 static void sshfs_file_get(struct sshfs_file *sf)
@@ -2651,7 +2762,7 @@ static int sshfs_release(const char *path, struct fuse_file_info *fi)
 	struct buffer *handle = &sf->handle;
 	if (sshfs_file_is_conn(sf)) {
 		sshfs_flush(path, fi);
-		sftp_request(SSH_FXP_CLOSE, handle, 0, NULL);
+		sftp_request_with(sf->conn, SSH_FXP_CLOSE, handle, 0, NULL);
 	}
 	buf_free(handle);
 	chunk_put_locked(sf->readahead);
@@ -2734,7 +2845,7 @@ static struct read_chunk *sshfs_send_read(struct sshfs_file *sf, size_t size,
 		buf_add_uint64(&buf, offset);
 		buf_add_uint32(&buf, bsize);
 		buf_to_iov(&buf, &iov[0]);
-		err = sftp_request_send(SSH_FXP_READ, iov, 1,
+		err = sftp_request_send(sf->conn, SSH_FXP_READ, iov, 1,
 					sshfs_read_begin,
 					sshfs_read_end,
 					0, rreq, NULL);
@@ -2952,7 +3063,7 @@ static int sshfs_async_write(struct sshfs_file *sf, const char *wbuf,
 		buf_to_iov(&buf, &iov[0]);
 		iov[1].iov_base = (void *) wbuf;
 		iov[1].iov_len = bsize;
-		err = sftp_request_send(SSH_FXP_WRITE, iov, 2,
+		err = sftp_request_send(sf->conn, SSH_FXP_WRITE, iov, 2,
 					sshfs_write_begin, sshfs_write_end,
 					0, sf, NULL);
 		buf_free(&buf);
@@ -3012,7 +3123,7 @@ static int sshfs_sync_write(struct sshfs_file *sf, const char *wbuf,
 		buf_to_iov(&buf, &iov[0]);
 		iov[1].iov_base = (void *) wbuf;
 		iov[1].iov_len = bsize;
-		err = sftp_request_send(SSH_FXP_WRITE, iov, 2,
+		err = sftp_request_send(sf->conn, SSH_FXP_WRITE, iov, 2,
 					sshfs_sync_write_begin,
 					sshfs_sync_write_end,
 					0, &sio, NULL);
@@ -3124,8 +3235,9 @@ static int sshfs_truncate(const char *path, off_t size,
 
 	buf_add_uint32(&buf, SSH_FILEXFER_ATTR_SIZE);
 	buf_add_uint64(&buf, size);
-	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
-			   &buf, SSH_FXP_STATUS, NULL);
+	err = sftp_request_with(sf == NULL ? NULL : sf->conn,
+				sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
+				&buf, SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
 
 	return err;
@@ -3154,7 +3266,8 @@ static int sshfs_getattr(const char *path, struct stat *stbuf,
 	}
 	else {
 		buf_add_buf(&buf, &sf->handle);
-		err = sftp_request(SSH_FXP_FSTAT, &buf, SSH_FXP_ATTRS, &outbuf);
+		err = sftp_request_with(sf->conn, SSH_FXP_FSTAT, &buf,
+					SSH_FXP_ATTRS, &outbuf);
 	}		
 	if (!err) {
 		err = buf_get_attrs(&outbuf, stbuf, NULL);
@@ -3291,7 +3404,8 @@ static int processing_init(void)
 	signal(SIGPIPE, SIG_IGN);
 
 	pthread_mutex_init(&sshfs.lock, NULL);
-	pthread_mutex_init(&sshfs.lock_write, NULL);
+	for (int i = 0; i < sshfs.max_conns; i++)
+		pthread_mutex_init(&sshfs.conns[i].lock_write, NULL);
 	pthread_cond_init(&sshfs.outstanding_cond, NULL);
 	sshfs.reqtab = g_hash_table_new(NULL, NULL);
 	if (!sshfs.reqtab) {
@@ -3387,6 +3501,7 @@ static void usage(const char *progname)
 "    -o follow_symlinks     follow symlinks on the server\n"
 "    -o no_check_root       don't check for existence of 'dir' on server\n"
 "    -o password_stdin      read password from stdin (only for pam_mount!)\n"
+"    -o max_conns=N         open parallel SSH connections\n"
 "    -o SSHOPT=VAL          ssh options (see man ssh_config)\n"
 "\n"
 "FUSE Options:\n",
@@ -3636,11 +3751,11 @@ static int ssh_connect(void)
 		return -1;
 
 	if (!sshfs.delay_connect) {
-		if (connect_remote() == -1)
+		if (connect_remote(&sshfs.conns[0]) == -1)
 			return -1;
 
 		if (!sshfs.no_check_root &&
-		    sftp_check_root(sshfs.base_path) != 0)
+		    sftp_check_root(&sshfs.conns[0], sshfs.base_path) != 0)
 			return -1;
 
 	}
@@ -3855,8 +3970,7 @@ int main(int argc, char *argv[])
 	sshfs.buflimit_workaround = 1;
 	sshfs.ssh_ver = 2;
 	sshfs.progname = argv[0];
-	sshfs.rfd = -1;
-	sshfs.wfd = -1;
+	sshfs.max_conns = 1;
 	sshfs.ptyfd = -1;
 	sshfs.dir_cache = 1;
 	sshfs.show_help = 0;
@@ -3946,7 +4060,7 @@ int main(int argc, char *argv[])
 
 	if (sshfs.debug)
 		sshfs.foreground = 1;
-	
+
 	if (sshfs.buflimit_workaround)
 		/* Work around buggy sftp-server in OpenSSH.  Without this on
 		   a slow server a 10Mbyte buffer would fill up and the server
@@ -3954,6 +4068,32 @@ int main(int argc, char *argv[])
 		sshfs.max_outstanding_len = 8388608;
 	else
 		sshfs.max_outstanding_len = ~0;
+
+	if (sshfs.max_conns > 1) {
+		if (sshfs.buflimit_workaround) {
+			fprintf(stderr, "buflimit workaround is not supported with parallel connections\n");
+			exit(1);
+		}
+
+		if (sshfs.password_stdin) {
+			fprintf(stderr, "password_stdin option cannot be specified with parallel connections\n");
+			exit(1);
+		}
+
+		if (sshfs.slave) {
+			fprintf(stderr, "slave option cannot be specified with parallel connections\n");
+			exit(1);
+		}
+	} else if (sshfs.max_conns <= 0) {
+		fprintf(stderr, "value of max_conns option must be at least 1\n");
+		exit(1);
+	}
+
+	sshfs.conns = g_new0(struct conn, sshfs.max_conns);
+	for (int i = 0; i < sshfs.max_conns; i++) {
+		sshfs.conns[i].rfd = -1;
+		sshfs.conns[i].wfd = -1;
+	}
 
 	fsname = g_strdup(sshfs.host);
 	sshfs.base_path = g_strdup(find_base_path());


### PR DESCRIPTION
The -o max_conns=N option causes multiple SSH processes and response
processing threads to be created.  Each file handle is locked to the
connection which was used for opening it.  One-off requests can use any
connection.

The connection is chosen by checking the per-connection statistics:

  1. Choose connection with least outstanding requests; if it's a tie,
  2. choose connection with least directory handles; if it's a tie,
  3. choose connection with least file handles; if it's a tie,
  4. choose connection which has already been established.

The implementation assumes that the max_conns values will be small; it
uses linear search.

The primary purpose of this feature is to improve the responsiveness of a
file system during large file transfers.  It also helps in scenarios
where the bandwidth of a single connection is limited, but multiple
connections are allowed, and the aggregate bandwidth limit is larger.

https://sourceforge.net/p/fuse/mailman/message/36076333/