### PR TITLE
Correct workaround condition for not using handle in sshfs_getattr

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,7 @@ Unreleased Changes
 * Make utimens(NULL) result in timestamp "now" -- no more touched files
   dated 1970-01-01
 * New `createmode` workaround.
+* Fix `fstat` workaround regression.
 
 Release 3.3.2 (2018-04-29)
 --------------------------

--- a/sshfs.c
+++ b/sshfs.c
@@ -3158,7 +3158,7 @@ static int sshfs_getattr(const char *path, struct stat *stbuf,
 	struct buffer outbuf;
 	struct sshfs_file *sf = NULL;
 
-	if (fi != NULL || sshfs.fstat_workaround) {
+	if (fi != NULL && !sshfs.fstat_workaround) {
 		sf = get_sshfs_file(fi);
 		if (!sshfs_file_is_conn(sf))
 			return -EIO;


### PR DESCRIPTION
In libfuse<3, when `fstat_workaround` was true, that meant to always
use the `path` argument to resolve fgetattr instead of the supplied
handle.  Before this change, the logic was interpreting
`fstat_workaround` to not use the `path` argument when it was
true. This change reverts to the libfuse<3 behavior.