### PR TITLE
Teach utimens to stamp with current time (#112)

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Make utimens(NULL) result in timestamp "now" -- no more touched files
+  dated 1970-01-01
 * New `createmode` workaround.
 
 Release 3.3.2 (2018-04-29)

--- a/sshfs.c
+++ b/sshfs.c
@@ -2473,6 +2473,14 @@ static int sshfs_utimens(const char *path, const struct timespec tv[2],
 	int err;
 	struct buffer buf;
 	struct sshfs_file *sf = NULL;
+	time_t asec = tv[0].tv_sec, msec = tv[1].tv_sec;
+
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	if (asec == 0)
+		asec = now.tv_sec;
+	if (msec == 0)
+		msec = now.tv_sec;
 
 	if (fi != NULL) {
 		sf = get_sshfs_file(fi);
@@ -2486,8 +2494,8 @@ static int sshfs_utimens(const char *path, const struct timespec tv[2],
 	else 
 		buf_add_buf(&buf, &sf->handle);
 	buf_add_uint32(&buf, SSH_FILEXFER_ATTR_ACMODTIME);
-	buf_add_uint32(&buf, tv[0].tv_sec);
-	buf_add_uint32(&buf, tv[1].tv_sec);
+	buf_add_uint32(&buf, asec);
+	buf_add_uint32(&buf, msec);
 
 	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
 			   &buf, SSH_FXP_STATUS, NULL);

--- a/test/test_sshfs.py
+++ b/test/test_sshfs.py
@@ -102,6 +102,7 @@ def test_sshfs(tmpdir, debug, cache_timeout, sync_rd, capfd):
         # SSHFS only supports one second resolution when setting
         # file timestamps.
         tst_utimens(mnt_dir, tol=1)
+        tst_utimens_now(mnt_dir)
 
         tst_link(mnt_dir, cache_timeout)
         tst_truncate_path(mnt_dir)
@@ -402,6 +403,18 @@ def tst_utimens(mnt_dir, tol=0):
     if sys.version_info >= (3,3):
         assert abs(fstat.st_atime_ns - atime_ns) < tol*1e9
         assert abs(fstat.st_mtime_ns - mtime_ns) < tol*1e9
+
+def tst_utimens_now(mnt_dir):
+    fullname = pjoin(mnt_dir, name_generator())
+
+    fd = os.open(fullname, os.O_CREAT | os.O_RDWR)
+    os.close(fd)
+    os.utime(fullname, None)
+
+    fstat = os.lstat(fullname)
+    # We should get now-timestamps
+    assert fstat.st_atime != 0
+    assert fstat.st_mtime != 0
 
 def tst_passthrough(src_dir, mnt_dir, cache_timeout):
     name = name_generator()


### PR DESCRIPTION
This is a first attempt. It sets current time for both atime and mtime, iff both passed `timeval.tv_sec` were `0`.

Is this sensible? Are we supposed to emulate `utimensat` as close as possible? Nah... Anyway, the filexfer proto use here only supports seconds precision... 