### PR TITLE
Support multiple connections

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Make utimens(NULL) result in timestamp "now" -- no more touched files
+  dated 1970-01-01
 * New `createmode` workaround.
 
 Release 3.3.2 (2018-04-29)

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,7 @@ Unreleased Changes
 * Make utimens(NULL) result in timestamp "now" -- no more touched files
   dated 1970-01-01
 * New `createmode` workaround.
+* Fix `fstat` workaround regression.
 
 Release 3.3.2 (2018-04-29)
 --------------------------

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,7 +5,10 @@ Unreleased Changes
   dated 1970-01-01
 * New `createmode` workaround.
 * Fix `fstat` workaround regression.
-
+* New max_conns option enables the use of multiple connections to
+  improve responsiveness during large file transfers. Rhanks to Timo
+  Savola for this feature!
+  
 Release 3.3.2 (2018-04-29)
 --------------------------
 

--- a/sshfs.c
+++ b/sshfs.c
@@ -2473,6 +2473,14 @@ static int sshfs_utimens(const char *path, const struct timespec tv[2],
 	int err;
 	struct buffer buf;
 	struct sshfs_file *sf = NULL;
+	time_t asec = tv[0].tv_sec, msec = tv[1].tv_sec;
+
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	if (asec == 0)
+		asec = now.tv_sec;
+	if (msec == 0)
+		msec = now.tv_sec;
 
 	if (fi != NULL) {
 		sf = get_sshfs_file(fi);
@@ -2486,8 +2494,8 @@ static int sshfs_utimens(const char *path, const struct timespec tv[2],
 	else 
 		buf_add_buf(&buf, &sf->handle);
 	buf_add_uint32(&buf, SSH_FILEXFER_ATTR_ACMODTIME);
-	buf_add_uint32(&buf, tv[0].tv_sec);
-	buf_add_uint32(&buf, tv[1].tv_sec);
+	buf_add_uint32(&buf, asec);
+	buf_add_uint32(&buf, msec);
 
 	err = sftp_request(sf == NULL ? SSH_FXP_SETSTAT : SSH_FXP_FSETSTAT,
 			   &buf, SSH_FXP_STATUS, NULL);

--- a/sshfs.c
+++ b/sshfs.c
@@ -3158,7 +3158,7 @@ static int sshfs_getattr(const char *path, struct stat *stbuf,
 	struct buffer outbuf;
 	struct sshfs_file *sf = NULL;
 
-	if (fi != NULL || sshfs.fstat_workaround) {
+	if (fi != NULL && !sshfs.fstat_workaround) {
 		sf = get_sshfs_file(fi);
 		if (!sshfs_file_is_conn(sf))
 			return -EIO;

--- a/sshfs.rst
+++ b/sshfs.rst
@@ -202,6 +202,14 @@ Options
    sets the interval for forced cleaning of the directory cache
    when full.
 
+-o max_conns=N
+   sets the maximum number of simultaneous SSH connections
+   to use. Each connection is established with a separate SSH process.
+   The primary purpose of this feature is to improve the responsiveness of the
+   file system during large file transfers. When using more than once
+   connection, the *password_stdin* and *slave* options can not be
+   used, and the *buflimit* workaround is not supported/
+   
 In addition, SSHFS accepts several options common to all FUSE file
 systems. These are described in the `mount.fuse` manpage (look
 for "general", "libfuse specific", and "high-level API" options).

--- a/test/test_sshfs.py
+++ b/test/test_sshfs.py
@@ -74,6 +74,9 @@ def test_sshfs(tmpdir, debug, cache_timeout, sync_rd, capfd):
     cmdline += [ '-o', 'entry_timeout=0',
                  '-o', 'attr_timeout=0' ]
 
+
+    cmdline += [ '-o', 'max_conns=3',
+                 '-o', 'workaround=nobuflimit' ]
     
     new_env = dict(os.environ) # copy, don't modify
 

--- a/test/test_sshfs.py
+++ b/test/test_sshfs.py
@@ -102,6 +102,7 @@ def test_sshfs(tmpdir, debug, cache_timeout, sync_rd, capfd):
         # SSHFS only supports one second resolution when setting
         # file timestamps.
         tst_utimens(mnt_dir, tol=1)
+        tst_utimens_now(mnt_dir)
 
         tst_link(mnt_dir, cache_timeout)
         tst_truncate_path(mnt_dir)
@@ -402,6 +403,18 @@ def tst_utimens(mnt_dir, tol=0):
     if sys.version_info >= (3,3):
         assert abs(fstat.st_atime_ns - atime_ns) < tol*1e9
         assert abs(fstat.st_mtime_ns - mtime_ns) < tol*1e9
+
+def tst_utimens_now(mnt_dir):
+    fullname = pjoin(mnt_dir, name_generator())
+
+    fd = os.open(fullname, os.O_CREAT | os.O_RDWR)
+    os.close(fd)
+    os.utime(fullname, None)
+
+    fstat = os.lstat(fullname)
+    # We should get now-timestamps
+    assert fstat.st_atime != 0
+    assert fstat.st_mtime != 0
 
 def tst_passthrough(src_dir, mnt_dir, cache_timeout):
     name = name_generator()


### PR DESCRIPTION
(This is a re-submit of PR #103 which was merged but then rolled back after tests failed)

Original description:

The -o max_conns=N option causes multiple SSH processes and response
processing threads to be created. Each file handle is locked to the
connection which was used for opening it. One-off requests can use any
connection.

The connection is chosen by checking the per-connection statistics:

    Choose connection with least outstanding requests; if it's a tie,
    choose connection with least directory handles; if it's a tie,
    choose connection with least file handles; if it's a tie,
    choose connection which has already been established.

The implementation assumes that the max_conns values will be small; it
uses linear search.

The primary purpose of this feature is to improve the responsiveness of a
file system during large file transfers. It also helps in scenarios
where the bandwidth of a single connection is limited, but multiple
connections are allowed, and the aggregate bandwidth limit is larger.

https://sourceforge.net/p/fuse/mailman/message/36076333/
