### PR TITLE
Port SSHFS to Cygwin

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,7 @@ Unreleased Changes
 ------------------
 
 * Fixed error code returned by rename(), allowing proper fallback.
+* Port to Cygwin.
 
 Release 3.4.0 (2018-06-29)
 --------------------------


### PR DESCRIPTION
This PR adds support for Cygwin to the latest version of SSHFS.

This requires [WinFsp 2018.2 B2](https://github.com/billziss-gh/winfsp/releases/tag/v1.4B2) or later and installation of the included "FUSE for Cygwin", which now supports FUSE 3.2.