### PR TITLE
Update clean_req() to match the definition of GHRFunc

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -1289,9 +1289,10 @@ static void chunk_put_locked(struct read_chunk *chunk)
 	pthread_mutex_unlock(&sshfs.lock);
 }
 
-static int clean_req(void *key_, struct request *req)
+static int clean_req(void *key_, struct request *req, gpointer user_data_)
 {
 	(void) key_;
+	(void) user_data_;
 
 	req->error = -EIO;
 	if (req->want_reply)


### PR DESCRIPTION
The current definition of the clean_req() function produces a compiler
warning as it expects 2 parameters but GHRFunc expects 3. This commit
resolves issue #157.

Cherry-picked from 7bc30513126ae02741feb2c39f0e835ba81597e6