### PR TITLE
Gracefully handle multiple spaces in ssh_command option

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,8 @@
+Unreleased Changes
+-------------------------
+
+* Fixed improper handling of sequential spaces spaces in "ssh_command" option
+
 Release 2.10 (2017-08-03)
 -------------------------
 


### PR DESCRIPTION
When using the "ssh_command" option, commands with multiple spaces in a
row will not be properly parsed. Example:

Properly parsed:
    ssh_command = "ssh -o IdentityFile=~/.ssh/id_rsa"

Improperly parsed:
    ssh_command = "ssh -o      IdentityFile=~/.ssh/id_rsa"

This commit changes the ssh_command parsing logic so that both of the
above examples are considered valid and properly handled. Resolves #114.