### PR TITLE
Added direct_io option

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+Unreleased Changes
+------------------
+
+* Added "-o direct_io" option.
+  This option disables the use of page cache in kernel.
+  This is useful for example if the file size is not known before reading it.
+  For example if you mount /proc dir from a remote host without the direct_io
+  option, the read always will return zero bytes instead of actual data.
+  
+
 Release 3.5.2 (2019-04-13)
 --------------------------
 

--- a/sshfs.c
+++ b/sshfs.c
@@ -244,6 +244,7 @@ struct sshfs {
 	int sync_write;
 	int sync_read;
 	int sync_readdir;
+  int direct_io;
 	int debug;
 	int foreground;
 	int reconnect;
@@ -408,6 +409,7 @@ static struct fuse_opt sshfs_opts[] = {
 	SSHFS_OPT("disable_hardlink",  disable_hardlink, 1),
 	SSHFS_OPT("dir_cache=yes", dir_cache, 1),
 	SSHFS_OPT("dir_cache=no",  dir_cache, 0),
+	SSHFS_OPT("direct_io",  direct_io, 1),
 
 	SSHFS_OPT("-h",		show_help, 1),
 	SSHFS_OPT("--help",	show_help, 1),
@@ -2509,6 +2511,9 @@ static int sshfs_open_common(const char *path, mode_t mode,
 	if (sshfs.dir_cache)
 		wrctr = cache_get_write_ctr();
 
+  if (sshfs.direct_io)
+    fi->direct_io = 1;
+
 	if ((fi->flags & O_ACCMODE) == O_RDONLY)
 		pflags = SSH_FXF_READ;
 	else if((fi->flags & O_ACCMODE) == O_WRONLY)
@@ -3369,6 +3374,7 @@ static void usage(const char *progname)
 "    -o dcache_min_clean_interval=N\n"
 "                           sets the interval for forced cleaning of the\n"
 "                           cache if full (default: 5)\n"
+"    -o direct_io           enable direct i/o\n"
 "    -o workaround=LIST     colon separated list of workarounds\n"
 "             none             no workarounds enabled\n"
 "             [no]rename       fix renaming to existing file (default: off)\n"

--- a/sshfs.rst
+++ b/sshfs.rst
@@ -202,6 +202,17 @@ Options
    sets the interval for forced cleaning of the directory cache
    when full.
 
+-o direct_io
+   This option disables the use of page cache (file content cache) in 
+   the kernel for this filesystem.
+   This has several affects:
+   1. Each read() or write() system call will initiate one or more read or
+      write operations, data will not be cached in the kernel.
+   2. The return value of the read() and write() system calls will correspond 
+      to the return values of the read and write operations. This is useful 
+      for example if the file size is not known in advance (before reading it).
+      e.g. /proc filesystem 
+
 In addition, SSHFS accepts several options common to all FUSE file
 systems. These are described in the `mount.fuse` manpage (look
 for "general", "libfuse specific", and "high-level API" options).


### PR DESCRIPTION
  This option disables the use of page cache in kernel.
  This is useful for example if the file size is not known before reading it. 
  For example if you mount /proc dir from a remote host without the direct_io
  option, the read always will return zero bytes instead of actual data.

[root@local ~]# sshfs root@remotehost:/proc /remote/
[root@local ~]# cat /remote/uptime 
[root@local ~]# fusermount -u /remote 
[root@local ~]# sshfs -o direct_io root@remotehost:/proc /remote/
[root@local ~]# cat /remote/uptime 
2280959.53 2221494.84
[root@local ~]# fusermount -u /remote