### PR TITLE
Include poll.h instead of sys/poll.h

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -38,7 +38,7 @@
 #include <sys/socket.h>
 #include <sys/utsname.h>
 #include <sys/mman.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <glib.h>


### PR DESCRIPTION
The standard header for the poll(3) interface is poll.h[0]. This prevents
a warning when building with musl libc:

    In file included from sshfs.c:44:
    /usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
     #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      ^~~~~~~

[0] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html