### PR TITLE
shfs: fix another instance preventing use of global I/O size on macOS

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3920,7 +3920,11 @@ int main(int argc, char *argv[])
 	}
 #endif /* __APPLE__ */
 
+#ifdef __APPLE__
+	sshfs.blksize = 0;
+#else
 	sshfs.blksize = 4096;
+#endif
 	/* SFTP spec says all servers should allow at least 32k I/O */
 	sshfs.max_read = 32768;
 	sshfs.max_write = 32768;


### PR DESCRIPTION
Following-up on [1], there was another instance where blksize was set to a non-zero value, thus making it impossible to configure global I/O size on macOS, and using [2] the hard-wired value of 4096 bytes instead, resulting in uniformly poor performance [3].

With this patch, setting I/O size to a reasonable large value, will result in much improved performance, e.g.: `-o iosize=1048576`

[1] https://github.com/osxfuse/sshfs/commit/5c0dbfe3eb40100f9277e863926f2e7d7c9a5a4c
[2] https://github.com/libfuse/sshfs/blob/4c21d696e9d46bebae0a936e2aec72326c5954ea/sshfs.c#L812
[3] https://github.com/libfuse/sshfs/issues/11#issuecomment-339407557
