### PR TITLE
Disable symlinks client side when "follow_symlinks" enabled

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -2154,6 +2154,9 @@ static int sshfs_readlink(const char *path, char *linkbuf, size_t size)
 	if (sshfs.server_version < 3)
 		return -EPERM;
 
+	if (sshfs.follow_symlinks)
+		return -EPERM;
+
 	buf_init(&buf, 0);
 	buf_add_path(&buf, path);
 	// Commutes with pending write(), so we can use any connection


### PR DESCRIPTION
When the "follow_symlinks" option is enabled, sshfs asks for the result
of stat instead of lstat. However, an untrusted server can still return
the result of lstat, and this can expose symlinks in the mount. So,
disable readlink in this case to disallow the use of these symlinks.