### PR TITLE
target libfuse version 30

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ sshfs_deps = [ dependency('fuse3', version: '>= 3.1.0'),
 executable('sshfs', sshfs_sources,
            include_directories: include_dirs,
            dependencies: sshfs_deps,
-           c_args: ['-DFUSE_USE_VERSION=31'],
+           c_args: ['-DFUSE_USE_VERSION=30'],
            install: true,
            install_dir: get_option('bindir'))
 


### PR DESCRIPTION
libfuse only defines fuse_new_30 when FUSE_USE_VERSION == 30. It does not
define fuse_new_31 in the headers.

fuse_new_31 and _32 seem to be internal only.

Fixes a linking issue:
ld: sshfs.p/sshfs.c.o: in function `main':
sshfs.c:(.text.startup+0x506): undefined reference to `fuse_new'
ld: sshfs.c:(.text.startup+0x506): undefined reference to `fuse_new'