### PR TITLE
Unset OLDPWD environment variable

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -1189,6 +1189,12 @@ static int start_ssh(struct conn *conn)
 			_exit(0);
 		}
 		chdir("/");
+		/*
+		 * Avoid processes hanging trying to stat() OLDPWD if it is in
+		 * the mount point. This can be removed if sshfs opens the
+		 * mount point after establishing the ssh connection.
+		 */
+		unsetenv("OLDPWD");
 
 		if (sshfs.password_stdin) {
 			int sfd;


### PR DESCRIPTION
If ssh is configured to use "Match exec" and the previous working
directory is the mount point, then the shell (bash) hangs calling
stat() on OLDPWD.

Unset OLDPWD so that this doesn't happen.

Fixes #206.