### PR TITLE
sshfs.c: fix build with gcc 4.8

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -1068,6 +1068,7 @@ static struct conn* get_conn(const struct sshfs_file *sf,
 			     const char *path)
 {
 	struct conntab_entry *ce;
+	int i;
 
 	if (sshfs.max_conns == 1)
 		return &sshfs.conns[0];
@@ -1089,7 +1090,7 @@ static struct conn* get_conn(const struct sshfs_file *sf,
 
 	int best_index = 0;
 	uint64_t best_score = ~0ULL; /* smaller is better */
-	for (int i = 0; i < sshfs.max_conns; i++) {
+	for (i = 0; i < sshfs.max_conns; i++) {
 		uint64_t score = ((uint64_t) sshfs.conns[i].req_count << 43) +
 				 ((uint64_t) sshfs.conns[i].dir_count << 22) +
 				 ((uint64_t) sshfs.conns[i].file_count << 1) +


### PR DESCRIPTION
Fix the following build failure with gcc 4.8:

```
../sshfs.c:1092:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (int i = 0; i < sshfs.max_conns; i++) {
  ^
```

This build failure has been added with https://github.com/libfuse/sshfs/commit/8822b60d9dbd9907065e7999f616b11ddce6d584

Fixes:
 - http://autobuild.buildroot.org/results/2dbdc579c55543175716d5f739cabe2ad0864ed6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>