### PR TITLE
Fix silently ignoring STATUS response after READ

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3012,8 +3012,9 @@ static int wait_chunk(struct read_chunk *chunk, char *buf, size_t size)
 
 		if (rreq->res < 0) {
 			chunk->sio.error = rreq->res;
+			res = chunk->sio.error;
 			break;
-		} if (rreq->res == 0) {
+		} else if (rreq->res == 0) {
 			chunk->sio.error = MY_EOF;
 			break;
 		} else if (size < (size_t) rreq->res) {


### PR DESCRIPTION
This attempts to fix #224, but is incomplete yet. Open questions:

- [ ] Does `res` need to be set in the immediately following else-if-branch and in the last else-branch as well? I guess not, because the case when `chunk->sio.error` equals `MY_EOF` is explicitly guarded a couple lines above.

- [ ] Do I need such a `MY_EOF` guard for the line that I added?

- [ ] When encountering an I/O error, SFTP reports a `SSH_FX_FAILURE` which, by the function `sftp_error_to_errno` is mapped to an `EPERM`. This leads to us getting an “Operation not permitted” over sshfs instead of an I/O error. Can `EPERM` be replaced by `EIO`?