### PR TITLE
Workaround for mkdir on existing directory

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+Unreleased Changes
+--------------------------
+
+* Added a secondary check so if a mkdir request fails with EPERM an access request will be
+  tried - returning EEXIST if the access was successful.
+	Fixes: https://github.com/libfuse/sshfs/issues/243
+
+
 Release 3.7.1 (2020-11-09)
 --------------------------
 

--- a/sshfs.c
+++ b/sshfs.c
@@ -2377,6 +2377,13 @@ static int sshfs_mkdir(const char *path, mode_t mode)
 	// Commutes with pending write(), so we can use any connection
 	err = sftp_request(get_conn(NULL, NULL), SSH_FXP_MKDIR, &buf, SSH_FXP_STATUS, NULL);
 	buf_free(&buf);
+	
+	if (err == -EPERM) {
+		if (sshfs.op->access(path, R_OK) == 0) {
+			return -EEXIST;
+		}
+	}
+	
 	return err;
 }
 


### PR DESCRIPTION
Added a secondary check so if a mkdir request fails with EPERM an access request will be tried - returning EEXIST if the access was successful. This matches the correct behaviour expected by applications such as git.