### PR TITLE
Add option "idle_disconnect"

### DIFF
--- a/sshfs.rst
+++ b/sshfs.rst
@@ -92,6 +92,10 @@ Options
    Don't immediately connect to server, wait until mountpoint is first
    accessed.
 
+-o idle_disconnect=N
+   Disconnect from server when idle for N seconds. When set, `-o reconnect` is
+   automatically set.
+
 -o sshfs_sync
    synchronous writes. This will slow things down, but may be useful
    in some situations.


### PR DESCRIPTION
I have a few sshfs mounts that I always have mounted, but only occasionally access. It feels a bit wasteful to maintain ssh connections so that they can just sit there.

This adds a new option, `-o idle_disconnect`, that causes a connection to disconnect once it has been idle for some number of seconds.