### PR TITLE
add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+d54c7ecbd618afb4df524e0d96dec7fe7cc2935d


### PR DESCRIPTION
Requires git >= 2.23. To enable this in your git client, run `git config --global blame.ignoreRevsFile .git-blame-ignore-revs`