### PR TITLE
Support request size negotiation and increased throughput on high-latency connections

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -1384,17 +1384,20 @@ static int sftp_read(struct conn *conn, uint8_t *type, struct buffer *buf)
 	buf_init(&buf2, 5);
 	res = do_read(conn, &buf2);
 	if (res != -1) {
-		if (buf_get_uint32(&buf2, &len) == -1)
-			return -1;
+		if ((res = buf_get_uint32(&buf2, &len)) == -1)
+			goto out;
 		if (len > MAX_REPLY_LEN) {
 			fprintf(stderr, "reply len too large: %u\n", len);
-			return -1;
+			res = -1;
+			goto out;
 		}
-		if (buf_get_uint8(&buf2, type) == -1)
-			return -1;
+		if ((res = buf_get_uint8(&buf2, type)) == -1) {
+			goto out;
+		}
 		buf_init(buf, len - 1);
 		res = do_read(conn, buf);
 	}
+out:
 	buf_free(&buf2);
 	return res;
 }

--- a/sshfs.c
+++ b/sshfs.c
@@ -2030,6 +2030,7 @@ static void *sshfs_init(struct fuse_conn_info *conn,
 	// SFTP only supports 1-second time resolution
 	conn->time_gran = 1000000000;
 
+	// TODO: Should this be based upon max_read?
 	if (sshfs.max_readahead > 0)
 		conn->max_readahead = sshfs.max_readahead;
 

--- a/sshfs.c
+++ b/sshfs.c
@@ -1827,6 +1827,8 @@ static int sftp_find_init_reply(struct conn *conn, uint32_t *version)
 	return res;
 }
 
+static int sftp_check_root(struct conn *conn, const char *base_path);
+static void sftp_detect_uid(struct conn *conn);
 static int sftp_init(struct conn *conn)
 {
 	int res = -1;

--- a/sshfs.c
+++ b/sshfs.c
@@ -1655,6 +1655,7 @@ static int sftp_init_limits(struct conn *conn) {
 		return res;
 	}
 	DEBUG("Parsed limits reply:\nread: %u write: %u\n", NULL);
+	apply_sftp_limits(&limits);
 	return 0;
 
 }

--- a/sshfs.c
+++ b/sshfs.c
@@ -330,6 +330,7 @@ struct sshfs {
 	GHashTable *r_uid_map;
 	GHashTable *r_gid_map;
 	unsigned max_read;
+	unsigned max_readahead;
 	unsigned max_write;
 	unsigned ssh_ver;
 	int sync_write;
@@ -474,6 +475,7 @@ static struct fuse_opt sshfs_opts[] = {
 	SSHFS_OPT("directport=%s",     directport, 0),
 	SSHFS_OPT("ssh_command=%s",    ssh_command, 0),
 	SSHFS_OPT("sftp_server=%s",    sftp_server, 0),
+	SSHFS_OPT("max_readahead=%u",  max_readahead, 0),
 	SSHFS_OPT("max_read=%u",       max_read, 0),
 	SSHFS_OPT("max_write=%u",      max_write, 0),
 	SSHFS_OPT("ssh_protocol=%u",   ssh_ver, 0),
@@ -1911,6 +1913,9 @@ static void *sshfs_init(struct fuse_conn_info *conn,
 
 	// SFTP only supports 1-second time resolution
 	conn->time_gran = 1000000000;
+
+	if (sshfs.max_readahead > 0)
+		conn->max_readahead = sshfs.max_readahead;
 
 	return NULL;
 }


### PR DESCRIPTION
I have found that a combination of increasing readahead and read limits to ~4MB has increased throughput from 1.1MB/s to 7.5MB/s on a connection with a 160ms round-trip time.

I need to submit another patch to the Linux kernel to allow configuring the readahead size. libfuse already seems to accept it as a parameter but the kernel side doesn't utilize it. Here's a patch that I used for testing which overrode the hard-coded limits   (based on [Ubuntu-hwe-5.4-5.4.0-79.88_18.04.1](https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/bionic/tree/?h=Ubuntu-hwe-5.4-5.4.0-79.88_18.04.1)): https://gist.github.com/ccope/0ff1cac336fceb827696c40715a4a828

The OpenSSH SFTP server recently added request limit negotiation, but it also has a fairly restrictive hard-coded cap. I need to file a patch to make that limit more configurable as well.

I reworked how the sftp init process is invoked to ensure limits get updated before forking more threads. In the process I created some high-level helper functions for sending requests and receiving responses without threads, and used them for all of the sftp init requests. I'd be happy to move them to a separate PR but I just kind of got tired of reworking my git history.