### PR TITLE
Fix typo in ssh_opts

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -432,7 +432,7 @@ static const char *ssh_opts[] = {
 	"ProxyCommand",
 	"ProxyJump",
 	"ProxyUseFdpass",
-	"PubkeyAcceptedKeyTypes"
+	"PubkeyAcceptedKeyTypes",
 	"PubkeyAuthentication",
 	"RekeyLimit",
 	"RevokedHostKeys",


### PR DESCRIPTION
Add a missing comma that prevents using the PubkeyAcceptedKeyTypes option