### PR TITLE
meson: allow explicitly disabling manpage generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sshfs', 'c', version: '3.7.2',
-        meson_version: '>= 0.40',
+        meson_version: '>= 0.47',
         default_options: [ 'buildtype=debugoptimized' ])
 
 add_global_arguments('-D_REENTRANT', '-DHAVE_CONFIG_H',
@@ -25,7 +25,7 @@ if not cc.compiles(code, args: [ '-O0', '-Werror=unused-result' ])
 endif
 
 
-rst2man = find_program('rst2man', 'rst2man.py', required: false)
+rst2man = find_program('rst2man', 'rst2man.py', required: get_option('build-manual'))
 
 cfg = configuration_data()
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('build-manual', type: 'feature', value: 'auto')


### PR DESCRIPTION
While manpage generation is optional depending on whether
'rst2man'/'rst2man.py' is found, a broken rst2man will still cause build
breakage.

For a build system like Buildroot, where manpages are anyway not needed,
it is preferred to be able to disable manpage generation altogether, to
avoid any impact of a broken user environment.

Add an option of type 'feature' which can be disabled explicitly as follows:
    -Dbuild-manual=disabled

In that case, even if rst2man would be present, the manpage would still not
be generated.

The 'feature' option type was added in meson 0.47, so bump the minimum meson
version accordingly.

See https://mesonbuild.com/Build-options.html#features .

Signed-off-by: Thomas De Schampheleire <thomas.de_schampheleire@nokia.com>