### PR TITLE
👷 use latest major version for actions/checkout

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
 


### PR DESCRIPTION
Use latest major version of [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.