### PR TITLE
Fix backslash escapes for `-o ssh_command`

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3931,6 +3931,7 @@ static char *tokenize_on_space(char *str)
 {
 	static char *pos = NULL;
 	char *start = NULL;
+	char *end = NULL;
 
 	if (str)
 		pos = str;
@@ -3943,22 +3944,27 @@ static char *tokenize_on_space(char *str)
 		pos++;
 
 	start = pos;
+	end = pos;
 
 	while (pos && *pos != '\0') {
 		// break on space, but not on '\ '
-		if (*pos == ' ' && *(pos - 1) != '\\') {
-			break;
+		if (*pos == ' ') {
+			if (*(pos - 1) == '\\') {
+				end--;
+			} else {
+				break;
+			}
 		}
-		pos++;
+		*end++ = *pos++;
 	}
 
 	if (*pos == '\0') {
 		pos = NULL;
 	}
 	else {
-		*pos = '\0';
 		pos++;
 	}
+	*end = '\0';
 
 	return start;
 }


### PR DESCRIPTION
The option previously supported escaping spaces with backslash, but this was broken at some point. Spaces are correctly skipped, but the backslashes are never removed. As a result, it is impossible to use commands with arguments that include spaces.

Note that escaping requires a double backslash. The first backslash is always removed by `fuse_opt_parse`'s own escape handling.