### PR TITLE
fix statfs divide-by-zero when blksize is 0

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -3382,7 +3382,7 @@ static int sshfs_statfs(const char *path, struct statvfs *buf)
 		return sshfs_ext_statvfs(path, buf);
 
 	buf->f_namemax = 255;
-	buf->f_bsize = sshfs.blksize;
+	buf->f_bsize = sshfs.blksize ? sshfs.blksize : 4096;
 	/*
 	 * df seems to use f_bsize instead of f_frsize, so make them
 	 * the same


### PR DESCRIPTION
On macOS, sshfs.blksize is set to 0. The statfs fallback path (used when the server lacks the statvfs extension) divides by f_frsize, which inherits that zero.

Use 4096 as the default when blksize is unset.

No test: this needs macOS blksize=0 plus a server without statvfs, which CI does not cover.