### PR TITLE
fix null-deref warning in tokenize_on_space, promote strict-warnings to required

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -102,7 +102,6 @@ jobs:
     name: ${{ matrix.compiler }} / strict warnings
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/sshfs.c
+++ b/sshfs.c
@@ -3954,7 +3954,7 @@ static char *tokenize_on_space(char *str)
 
 	start = pos;
 
-	while (pos && *pos != '\0') {
+	while (*pos != '\0') {
 		// break on space, but not on '\ '
 		if (*pos == ' ' && *(pos - 1) != '\\') {
 			break;


### PR DESCRIPTION
Remove redundant NULL guard in `tokenize_on_space()` that confused gcc's null-dereference analysis. `pos` is guaranteed non-NULL at that point (checked on line 3948, and `pos++` cannot produce NULL).

With the warning fixed, remove `continue-on-error: true` from the strict-warnings CI job so both gcc and clang strict-warning builds are now required.

Stacked on #353.