### PR TITLE
fix: replace assert(offset==0) with early return in readdir

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -386,7 +386,13 @@ static int cache_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	struct node *node;
 	struct cache_dirent **cdent;
 
-	assert(offset == 0);
+#ifndef __APPLE__
+	assert(offset == 0);  /* keep for non-macOS; see sshfs.c sftp_readdir_async */
+#endif	
+	/* On macOS with macFUSE 5.3.x / FSKit, may be called with offset != 0.
+	 * All entries were already returned in the first (offset=0) call. */
+	if (offset != 0)
+		return 0;
 
 	pthread_mutex_lock(&cache.lock);
 	node = cache_lookup(path);

--- a/sshfs.c
+++ b/sshfs.c
@@ -2318,7 +2318,21 @@ static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
 
 	int done = 0;
 
-	assert(offset == 0);
+	/*
+	 * sshfs uses old-style readdir (filler always called with offset=0),
+	 * so FUSE should return all entries in one call (offset=0).
+	 * On macOS with macFUSE 5.3.x / FSKit backend, Finder or Spotlight
+	 * may call readdir again with a non-zero offset even in old-style mode.
+	 * When that happens, all entries were already returned in the first
+	 * call, so we can safely return 0 (no more entries) instead of crashing.
+	 * See: https://github.com/libfuse/sshfs/issues/338
+	 */
+#ifndef __APPLE__
+ assert(offset == 0);
+#endif
+	if (offset != 0)
+		return 0;
+
 	while (!done || outstanding) {
 		struct request *req;
 		struct buffer name;
@@ -2390,7 +2404,13 @@ static int sftp_readdir_sync(struct conn *conn, struct buffer *handle,
 			     void *buf, off_t offset, fuse_fill_dir_t filler)
 {
 	int err;
+	/* See comment in sftp_readdir_async for why offset != 0 is handled
+	 * this way instead of asserting. */
+#ifndef __APPLE__
 	assert(offset == 0);
+#endif	
+ if (offset != 0)
+		return 0;
 	do {
 		struct buffer name;
 		err = sftp_request(conn, SSH_FXP_READDIR, handle, SSH_FXP_NAME, &name);


### PR DESCRIPTION
On macOS with macFUSE 5.3.x (FSKit backend) and macOS 27 Golden Gate beta, Finder/Spotlight may call readdir with a non-zero offset even when fuse_fill_dir is always called with offset=0 (old-style readdir). This triggers the assert and aborts the sshfs process.

Replace assert(offset == 0) with if (offset != 0) return 0 in:
- sftp_readdir_async() in sshfs.c
- sftp_readdir_sync() in sshfs.c
- cache_readdir() in cache.c

Since all entries are returned in the first (offset=0) call, returning 0 on subsequent calls is semantically correct and prevents the crash.

Fixes: https://github.com/libfuse/sshfs/issues/338
Tested: macOS 27 Golden Gate beta 2, macFUSE 5.3.2