### PR TITLE
macOS: do not call fuse_session_fd before fuse_daemonise

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -4518,7 +4518,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-#if !defined(__CYGWIN__)
+#if !defined(__CYGWIN__) && !defined(__APPLE__)
 	res = fcntl(fuse_session_fd(se), F_SETFD, FD_CLOEXEC);
 	if (res == -1)
 		perror("WARNING: failed to set FD_CLOEXEC on fuse device");


### PR DESCRIPTION
This appears to be the right sequence and also fixes ObjC/fork issues on macOS with macFUSE 5.2.0+ (see #373).