### PR TITLE
fix: handle readdir offset != 0 by snapshotting the directory

### DIFF
--- a/cache.c
+++ b/cache.c
@@ -8,7 +8,6 @@
 
 #include "cache.h"
 #include <stdio.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -386,13 +385,18 @@ static int cache_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	struct node *node;
 	struct cache_dirent **cdent;
 
-#ifndef __APPLE__
-	assert(offset == 0);  /* keep for non-macOS; see sshfs.c sftp_readdir_async */
-#endif	
-	/* On macOS with macFUSE 5.3.x / FSKit, may be called with offset != 0.
-	 * All entries were already returned in the first (offset=0) call. */
-	if (offset != 0)
-		return 0;
+	/*
+	 * sshfs uses mode-1 readdir: the offset parameter is ignored and the
+	 * complete listing is always handed to the filler with offset 0;
+	 * libfuse caches the entries and does the offset-based slicing
+	 * itself.  Being called with a non-zero offset is valid (e.g. FSKit
+	 * on macOS resuming an enumeration from a saved cookie with a fresh
+	 * directory handle) and must still produce the full listing --
+	 * returning nothing here would be interpreted as an empty directory
+	 * and make entries silently vanish.
+	 * See: https://github.com/libfuse/sshfs/issues/338
+	 */
+	(void) offset;
 
 	pthread_mutex_lock(&cache.lock);
 	node = cache_lookup(path);
@@ -427,7 +431,8 @@ static int cache_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	ch.dir = g_ptr_array_new();
 	g_ptr_array_set_free_func(ch.dir, free_cache_dirent);
 	ch.wrctr = cache_get_write_ctr();
-	err = cache.next_oper->readdir(path, &ch, cache_dirfill, offset, fi, flags);
+	/* Always request a fresh, complete enumeration to (re)fill the cache */
+	err = cache.next_oper->readdir(path, &ch, cache_dirfill, 0, fi, flags);
 	g_ptr_array_add(ch.dir, NULL);
 	dir = ch.dir;
 	if (!err) {

--- a/cache.c
+++ b/cache.c
@@ -386,7 +386,13 @@ static int cache_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	struct node *node;
 	struct cache_dirent **cdent;
 
-	assert(offset == 0);
+#ifndef __APPLE__
+	assert(offset == 0);  /* keep for non-macOS; see sshfs.c sftp_readdir_async */
+#endif	
+	/* On macOS with macFUSE 5.3.x / FSKit, may be called with offset != 0.
+	 * All entries were already returned in the first (offset=0) call. */
+	if (offset != 0)
+		return 0;
 
 	pthread_mutex_lock(&cache.lock);
 	node = cache_lookup(path);

--- a/sshfs.c
+++ b/sshfs.c
@@ -2318,7 +2318,21 @@ static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
 
 	int done = 0;
 
-	assert(offset == 0);
+	/*
+	 * sshfs uses old-style readdir (filler always called with offset=0),
+	 * so FUSE should return all entries in one call (offset=0).
+	 * On macOS with macFUSE 5.3.x / FSKit backend, Finder or Spotlight
+	 * may call readdir again with a non-zero offset even in old-style mode.
+	 * When that happens, all entries were already returned in the first
+	 * call, so we can safely return 0 (no more entries) instead of crashing.
+	 * See: https://github.com/libfuse/sshfs/issues/338
+	 */
+#ifndef __APPLE__
+ assert(offset == 0);
+#endif
+	if (offset != 0)
+		return 0;
+
 	while (!done || outstanding) {
 		struct request *req;
 		struct buffer name;
@@ -2390,7 +2404,13 @@ static int sftp_readdir_sync(struct conn *conn, struct buffer *handle,
 			     void *buf, off_t offset, fuse_fill_dir_t filler)
 {
 	int err;
+	/* See comment in sftp_readdir_async for why offset != 0 is handled
+	 * this way instead of asserting. */
+#ifndef __APPLE__
 	assert(offset == 0);
+#endif	
+ if (offset != 0)
+		return 0;
 	do {
 		struct buffer name;
 		err = sftp_request(conn, SSH_FXP_READDIR, handle, SSH_FXP_NAME, &name);

--- a/sshfs.c
+++ b/sshfs.c
@@ -237,16 +237,20 @@ struct dir_handle {
 	struct buffer buf;
 	struct conn *conn;
 	/*
-	 * Cached snapshot of the whole directory listing. sshfs uses
-	 * old-style readdir and the underlying SFTP directory handle is
-	 * single-pass, so we read the entire directory once and serve every
-	 * readdir call (with any offset, including offset==0 rewinds issued
-	 * by macFUSE) from this snapshot. See:
+	 * Snapshot of the *current* enumeration. sshfs uses old-style readdir
+	 * over a single-pass SFTP directory handle. Each new enumeration
+	 * (offset == 0, e.g. a fresh listing or a rewinddir) re-reads the
+	 * directory from the server so newly created files and updated
+	 * attributes show up; a continuation (offset != 0) is served from this
+	 * snapshot so the listing never comes back empty when the handle has
+	 * already been exhausted. See:
 	 * https://github.com/libfuse/sshfs/issues/338
 	 */
 	GPtrArray *entries;	/* array of struct dir_entry * */
-	int read_done;		/* directory has been read from the server */
-	int read_err;		/* error from reading the directory, if any */
+	char *path;		/* directory path, for reopening the handle */
+	int read_err;		/* error from the last read, if any */
+	int has_handle;		/* buf holds an open SFTP dir handle to close */
+	int buf_exhausted;	/* the SFTP handle has been read to EOF */
 };
 
 struct list_head {
@@ -2445,6 +2449,8 @@ static int sshfs_opendir(const char *path, struct fuse_file_info *fi)
 		handle->conn = conn;
 		handle->conn->dir_count++;
 		pthread_mutex_unlock(&sshfs.lock);
+		handle->has_handle = 1;
+		handle->path = g_strdup(path);
 		fi->fh = (unsigned long) handle;
 	} else
 		g_free(handle);
@@ -2459,34 +2465,73 @@ static void free_dir_entry(gpointer data)
 	g_free(entry);
 }
 
+/*
+ * Reopen the SFTP directory handle. SFTP has no rewind, so re-reading a
+ * directory from the start means closing the exhausted handle and opening a
+ * fresh one.
+ */
+static int sshfs_reopen_dir(struct dir_handle *handle)
+{
+	struct buffer buf;
+	int err;
+
+	if (handle->has_handle) {
+		sftp_request(handle->conn, SSH_FXP_CLOSE, &handle->buf, 0, NULL);
+		/* free + reset to a clean state so sftp_request can refill it */
+		buf_clear(&handle->buf);
+		handle->has_handle = 0;
+	}
+	buf_init(&buf, 0);
+	buf_add_path(&buf, handle->path);
+	err = sftp_request(handle->conn, SSH_FXP_OPENDIR, &buf,
+			   SSH_FXP_HANDLE, &handle->buf);
+	buf_free(&buf);
+	if (!err) {
+		buf_finish(&handle->buf);
+		handle->has_handle = 1;
+		handle->buf_exhausted = 0;
+	}
+	return err;
+}
+
 static int sshfs_readdir(const char *path, void *dbuf, fuse_fill_dir_t filler,
 			 off_t offset, struct fuse_file_info *fi,
 			 enum fuse_readdir_flags flags)
 {
-	(void) path; (void) flags; (void) offset;
+	(void) path; (void) flags;
 	unsigned i;
 	struct dir_handle *handle;
 
 	handle = (struct dir_handle*) fi->fh;
 
 	/*
-	 * Read the whole directory into a cached snapshot on the first call.
-	 * The SFTP directory handle is single-pass, so this snapshot is what
-	 * lets us serve repeated readdir calls (any offset, including
-	 * offset==0 rewinds from macFUSE) without the directory contents
-	 * vanishing. See: https://github.com/libfuse/sshfs/issues/338
+	 * offset == 0 starts a fresh enumeration (a new listing or a
+	 * rewinddir), so re-read the directory from the server to pick up newly
+	 * created files and updated attributes. The SFTP handle is single-pass:
+	 * once read to EOF, reusing it would read nothing and the directory
+	 * would appear empty, so we reopen a fresh handle first. offset != 0 is
+	 * a continuation of the current enumeration and is served from the
+	 * snapshot taken at offset 0.
+	 * See: https://github.com/libfuse/sshfs/issues/338
 	 */
-	if (!handle->read_done) {
-		handle->entries = g_ptr_array_new_with_free_func(free_dir_entry);
-		if (sshfs.sync_readdir)
-			handle->read_err = sftp_readdir_sync(handle->conn,
-							     &handle->buf,
-							     handle->entries);
-		else
-			handle->read_err = sftp_readdir_async(handle->conn,
-							      &handle->buf,
-							      handle->entries);
-		handle->read_done = 1;
+	if (offset == 0 || handle->entries == NULL) {
+		if (handle->buf_exhausted)
+			handle->read_err = sshfs_reopen_dir(handle);
+		if (!handle->read_err) {
+			if (handle->entries)
+				g_ptr_array_free(handle->entries, TRUE);
+			handle->entries =
+				g_ptr_array_new_with_free_func(free_dir_entry);
+			if (sshfs.sync_readdir)
+				handle->read_err = sftp_readdir_sync(
+					handle->conn, &handle->buf,
+					handle->entries);
+			else
+				handle->read_err = sftp_readdir_async(
+					handle->conn, &handle->buf,
+					handle->entries);
+			handle->buf_exhausted = 1;
+		}
 	}
 
 	if (handle->read_err)
@@ -2511,13 +2556,18 @@ static int sshfs_releasedir(const char *path, struct fuse_file_info *fi)
 	struct dir_handle *handle;
 
 	handle = (struct dir_handle*) fi->fh;
-	err = sftp_request(handle->conn, SSH_FXP_CLOSE, &handle->buf, 0, NULL);
+	err = 0;
+	if (handle->has_handle) {
+		err = sftp_request(handle->conn, SSH_FXP_CLOSE, &handle->buf,
+				   0, NULL);
+		buf_free(&handle->buf);
+	}
 	pthread_mutex_lock(&sshfs.lock);
 	handle->conn->dir_count--;
 	pthread_mutex_unlock(&sshfs.lock);
-	buf_free(&handle->buf);
 	if (handle->entries)
 		g_ptr_array_free(handle->entries, TRUE);
+	g_free(handle->path);
 	g_free(handle);
 	return err;
 }

--- a/sshfs.c
+++ b/sshfs.c
@@ -228,9 +228,25 @@ struct buffer {
 	size_t size;
 };
 
+struct dir_entry {
+	char *name;
+	struct stat stbuf;
+};
+
 struct dir_handle {
 	struct buffer buf;
 	struct conn *conn;
+	/*
+	 * Cached snapshot of the whole directory listing. sshfs uses
+	 * old-style readdir and the underlying SFTP directory handle is
+	 * single-pass, so we read the entire directory once and serve every
+	 * readdir call (with any offset, including offset==0 rewinds issued
+	 * by macFUSE) from this snapshot. See:
+	 * https://github.com/libfuse/sshfs/issues/338
+	 */
+	GPtrArray *entries;	/* array of struct dir_entry * */
+	int read_done;		/* directory has been read from the server */
+	int read_err;		/* error from reading the directory, if any */
 };
 
 struct list_head {
@@ -958,8 +974,7 @@ static int buf_get_statvfs(struct buffer *buf, struct statvfs *stbuf)
 	return 0;
 }
 
-static int buf_get_entries(struct buffer *buf, void *dbuf,
-                           fuse_fill_dir_t filler)
+static int buf_get_entries(struct buffer *buf, GPtrArray *entries)
 {
 	uint32_t count;
 	unsigned i;
@@ -978,11 +993,16 @@ static int buf_get_entries(struct buffer *buf, void *dbuf,
 			free(longname);
 			err = buf_get_attrs(buf, &stbuf, NULL);
 			if (!err) {
+				struct dir_entry *entry;
 				if (sshfs.follow_symlinks &&
 				    S_ISLNK(stbuf.st_mode)) {
 					stbuf.st_mode = 0;
 				}
-				filler(dbuf, name, &stbuf, 0, 0);
+				entry = g_new(struct dir_entry, 1);
+				entry->name = name;
+				entry->stbuf = stbuf;
+				g_ptr_array_add(entries, entry);
+				name = NULL; /* ownership passed to entry */
 			}
 		}
 		free(name);
@@ -2309,7 +2329,7 @@ static int sshfs_req_pending(struct request *req)
 }
 
 static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
-			      void *buf, off_t offset, fuse_fill_dir_t filler)
+			      GPtrArray *entries)
 {
 	int err = 0;
 	int outstanding = 0;
@@ -2317,21 +2337,6 @@ static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
 	GList *list = NULL;
 
 	int done = 0;
-
-	/*
-	 * sshfs uses old-style readdir (filler always called with offset=0),
-	 * so FUSE should return all entries in one call (offset=0).
-	 * On macOS with macFUSE 5.3.x / FSKit backend, Finder or Spotlight
-	 * may call readdir again with a non-zero offset even in old-style mode.
-	 * When that happens, all entries were already returned in the first
-	 * call, so we can safely return 0 (no more entries) instead of crashing.
-	 * See: https://github.com/libfuse/sshfs/issues/338
-	 */
-#ifndef __APPLE__
- assert(offset == 0);
-#endif
-	if (offset != 0)
-		return 0;
 
 	while (!done || outstanding) {
 		struct request *req;
@@ -2383,7 +2388,7 @@ static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
 				done = 1;
 			}
 			if (!done) {
-				err = buf_get_entries(&name, buf, filler);
+				err = buf_get_entries(&name, entries);
 				buf_free(&name);
 
 				/* increase number of outstanding requests */
@@ -2401,21 +2406,14 @@ static int sftp_readdir_async(struct conn *conn, struct buffer *handle,
 }
 
 static int sftp_readdir_sync(struct conn *conn, struct buffer *handle,
-			     void *buf, off_t offset, fuse_fill_dir_t filler)
+			     GPtrArray *entries)
 {
 	int err;
-	/* See comment in sftp_readdir_async for why offset != 0 is handled
-	 * this way instead of asserting. */
-#ifndef __APPLE__
-	assert(offset == 0);
-#endif	
- if (offset != 0)
-		return 0;
 	do {
 		struct buffer name;
 		err = sftp_request(conn, SSH_FXP_READDIR, handle, SSH_FXP_NAME, &name);
 		if (!err) {
-			err = buf_get_entries(&name, buf, filler);
+			err = buf_get_entries(&name, entries);
 			buf_free(&name);
 		}
 	} while (!err);
@@ -2454,24 +2452,56 @@ static int sshfs_opendir(const char *path, struct fuse_file_info *fi)
 	return err;
 }
 
+static void free_dir_entry(gpointer data)
+{
+	struct dir_entry *entry = data;
+	free(entry->name);
+	g_free(entry);
+}
+
 static int sshfs_readdir(const char *path, void *dbuf, fuse_fill_dir_t filler,
 			 off_t offset, struct fuse_file_info *fi,
 			 enum fuse_readdir_flags flags)
 {
-	(void) path; (void) flags;
-	int err;
+	(void) path; (void) flags; (void) offset;
+	unsigned i;
 	struct dir_handle *handle;
 
 	handle = (struct dir_handle*) fi->fh;
 
-	if (sshfs.sync_readdir)
-		err = sftp_readdir_sync(handle->conn, &handle->buf, dbuf,
-					offset, filler);
-	else
-		err = sftp_readdir_async(handle->conn, &handle->buf, dbuf,
-					 offset, filler);
+	/*
+	 * Read the whole directory into a cached snapshot on the first call.
+	 * The SFTP directory handle is single-pass, so this snapshot is what
+	 * lets us serve repeated readdir calls (any offset, including
+	 * offset==0 rewinds from macFUSE) without the directory contents
+	 * vanishing. See: https://github.com/libfuse/sshfs/issues/338
+	 */
+	if (!handle->read_done) {
+		handle->entries = g_ptr_array_new_with_free_func(free_dir_entry);
+		if (sshfs.sync_readdir)
+			handle->read_err = sftp_readdir_sync(handle->conn,
+							     &handle->buf,
+							     handle->entries);
+		else
+			handle->read_err = sftp_readdir_async(handle->conn,
+							      &handle->buf,
+							      handle->entries);
+		handle->read_done = 1;
+	}
 
-	return err;
+	if (handle->read_err)
+		return handle->read_err;
+
+	/*
+	 * Old-style readdir: hand FUSE the complete listing with offset 0 and
+	 * let it do the offset-based slicing itself.
+	 */
+	for (i = 0; i < handle->entries->len; i++) {
+		struct dir_entry *entry = g_ptr_array_index(handle->entries, i);
+		filler(dbuf, entry->name, &entry->stbuf, 0, 0);
+	}
+
+	return 0;
 }
 
 static int sshfs_releasedir(const char *path, struct fuse_file_info *fi)
@@ -2486,6 +2516,8 @@ static int sshfs_releasedir(const char *path, struct fuse_file_info *fi)
 	handle->conn->dir_count--;
 	pthread_mutex_unlock(&sshfs.lock);
 	buf_free(&handle->buf);
+	if (handle->entries)
+		g_ptr_array_free(handle->entries, TRUE);
 	g_free(handle);
 	return err;
 }


### PR DESCRIPTION
Replaces #371 (closed).

## Problem

sshfs uses mode-1 readdir — it ignores the offset and hands the whole listing to the filler with offset 0 — but also *asserted* `offset == 0` in three places:

- `sftp_readdir_async()` (sshfs.c)
- `sftp_readdir_sync()` (sshfs.c)
- `cache_readdir()` (cache.c)

That assertion is an invalid assumption, and a long-standing one. Calling readdir with `offset != 0` is legal, and the mismatch was already reported in #211 (2020, on FreeBSD via `seekdir`) — where @Nikratio confirmed the code "is buggy ... it certainly can be fixed" and suggested exactly this fix: "always retrieve the full list from the SFTP server and buffer it in memory." A mode-1 filesystem must still return the full listing when called with a non-zero offset, rather than assert or return nothing.

The bug only became acute on macOS with macFUSE 5.3.x. macFUSE is transitioning its backend from the kernel extension toward Apple's FSKit framework (as macOS deprecates third-party kexts), and as part of that transition 5.3.x reworked directory enumeration — 5.3.1 switched to the node identifier and generation as the authoritative handle instead of the inode number, and added a `FUSE_LOOKUP` on the entries returned by `FUSE_READDIR`. We can only speculate that this is why `readdir` is now called with `offset != 0` so much more often (#338), but the fix does not depend on the cause. It is sshfs's own contract violation — the process aborts on the assert, and the earlier `return 0` attempt (#371) empties the listing instead — and it is observed on macFUSE 5.3.x on both the FSKit and kernel-extension backends.

## Fix

Remove the `assert(offset == 0)` in all three locations (and drop the now-unused `#include <assert.h>` from cache.c), and handle a non-zero offset correctly by buffering the whole directory, along the lines @Nikratio suggested:

- `sshfs_readdir()` keeps a snapshot of the current enumeration. An SFTP directory handle is single-pass — once read to `SSH_FX_EOF` it yields nothing — so on `offset == 0` (a fresh listing or a rewinddir) it re-opens the handle if it has been exhausted and re-reads the whole directory from the server, rebuilding the snapshot. A continuation (`offset != 0`) is served from that snapshot, always filling with offset 0 so libfuse does the slicing.
- Because each fresh enumeration re-reads from the server, **newly created files and updated attributes show up on the next listing** rather than being masked by a stale snapshot. This was a real regression while the snapshot was retained across enumerations — @dmik observed newly created files not appearing under a VS Code workload — and is why the re-read happens on every `offset == 0` rather than once per open handle.
- `cache_readdir()` ignores the offset entirely and, when the cache is stale, always requests a fresh, complete enumeration. (@dmik confirmed the vanishing itself was not caused by caching — it reproduced with the cache disabled — so this is for contract-correctness, not the primary fix.)

No platform `#ifdef` is involved: handling `offset != 0` this way is correct on every platform, so the assertions are dropped unconditionally.

## Testing

@dmik stress-tested this branch (VS Code on a large `.git` project, overnight idle with `-o ServerAliveInterval=15 -o ServerAliveCountMax=3`), including the newly-created-files case, and reports stable directory listings and file editing (#338).

Refs: #338, #371, #211
