### PR TITLE
macos: defer FD_CLOEXEC fcntl until after fuse_daemonize()

### DIFF
--- a/sshfs.c
+++ b/sshfs.c
@@ -4518,7 +4518,11 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-#if !defined(__CYGWIN__)
+	/*
+	 * On macOS the FD_CLOEXEC fcntl is deferred until after
+	 * fuse_daemonize() below; see the comment there.
+	 */
+#if !defined(__CYGWIN__) && !defined(__APPLE__)
 	res = fcntl(fuse_session_fd(se), F_SETFD, FD_CLOEXEC);
 	if (res == -1)
 		perror("WARNING: failed to set FD_CLOEXEC on fuse device");
@@ -4541,6 +4545,30 @@ int main(int argc, char *argv[])
 		fuse_destroy(fuse);
 		exit(1);
 	}
+
+#ifdef __APPLE__
+	/*
+	 * macFUSE 5.3.3+ mounts lazily: fuse_mount() only records the request,
+	 * and the real mount (and its XPC channel) is created on first use.
+	 * On macOS fuse_session_fd() is such a first use -- it triggers the
+	 * delayed mount and marks the mount as started, after which
+	 * fuse_daemonize() refuses to fork and stays in the foreground
+	 * ("daemonize requested after mount started; continuing in foreground").
+	 *
+	 * So defer the FD_CLOEXEC fcntl until here, after daemonizing: the
+	 * mount is then created in the daemon child, where its XPC connection
+	 * survives, and daemonization still forks as before. The fuse fd does
+	 * not exist yet while the first ssh child is spawned in ssh_connect()
+	 * above, so nothing can leak in that window; setting FD_CLOEXEC now
+	 * still protects the ssh children spawned later on reconnect.
+	 *
+	 * See macFUSE commit 867b5cdb ("Defer mount process until first use on
+	 * macOS") and https://github.com/libfuse/sshfs/issues/338
+	 */
+	res = fcntl(fuse_session_fd(se), F_SETFD, FD_CLOEXEC);
+	if (res == -1)
+		perror("WARNING: failed to set FD_CLOEXEC on fuse device");
+#endif
 
 	if (sshfs.singlethread)
 		res = fuse_loop(fuse);


### PR DESCRIPTION
## Problem

On macOS with macFUSE 5.3.3, sshfs can no longer daemonize into the background. Mounting without `-f` prints

```
fuse: daemonize requested after mount started; continuing in foreground
```

and the process stays attached to the terminal, even though sshfs's own code hasn't changed. @dmik independently hit this in #371 and suggested that "sshfs daemonization should be changed so that it happens before triggering `MFMount` use"; this PR does exactly that.

## Root cause

macFUSE 5.3.3 mounts lazily: `fuse_session_mount()` (called by `fuse_mount()`) only records the request, and the real mount — including its XPC channel — is created on first use, after the normal `fuse_main()` daemonization point. Once that mount has started, `fuse_daemonize()` deliberately refuses to fork, because the XPC connection cannot survive a fork.

The catch is that `fuse_session_fd()` is one of those "first uses". Since macFUSE commit `867b5cdb` ("Defer mount process until first use on macOS") it went from a plain getter to routing through `fuse_session_mfch()`, which triggers the delayed mount:

```
fuse_session_fd(se)
  └─ fuse_session_mfch(se)            // state == FUSE_DARWIN_MOUNT_DELAYED
       ├─ fuse_darwin_set_mount_started()   // sticky "mount started" flag
       └─ fuse_session_mount_real(se)       // the real mount + XPC channel
```

sshfs calls `fuse_session_fd()` between `fuse_mount()` and `fuse_daemonize()` purely to set `FD_CLOEXEC` on the fuse device:

```c
res = fcntl(fuse_session_fd(se), F_SETFD, FD_CLOEXEC);
```

On 5.3.3 that call now materializes the mount *before* daemonizing, so by the time `fuse_daemonize()` checks `fuse_darwin_mount_started()` it is already set, and sshfs stays in the foreground.

## Fix

Defer the `FD_CLOEXEC` fcntl on macOS until *after* `fuse_daemonize()`. The upstream `mount → connect → daemonize` order is otherwise unchanged.

This is safe:

- The fuse fd does not exist yet while the first `ssh` child is spawned in `ssh_connect()` (the delayed mount hasn't been triggered), so there is nothing to leak in that window.
- After daemonizing, the fcntl triggers the mount in the daemon child — where the XPC connection survives — and still sets `FD_CLOEXEC` before any `ssh` child is re-spawned on `-o reconnect`.

Non-macOS platforms keep the fcntl in its original place (before `ssh_connect()`), where it must stay because the fuse fd exists from `fuse_mount()` onward. This makes sshfs on macOS behave like `fuse_main()`, which never touches the session fd before daemonizing.

## Testing

macOS 27 + macFUSE 5.3.3, key auth, no `-f`: the process now daemonizes to the background (`PPID == 1`), the mount completes in the daemon child, the SSH connection survives, and directory enumeration works. The foreground fallback no longer triggers.

Refs: #338, #371
